### PR TITLE
Disable non skipping group optimization.

### DIFF
--- a/build-logic/src/main/kotlin/io/github/reactivecircus/kstreamlined/buildlogic/convention/ComposeConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/reactivecircus/kstreamlined/buildlogic/convention/ComposeConventionPlugin.kt
@@ -13,7 +13,6 @@ internal class ComposeConventionPlugin : Plugin<Project> {
         configure<ComposeCompilerGradlePluginExtension> {
             suppressKotlinVersionCompatibilityCheck.set(the<LibrariesForLibs>().versions.kotlin.get())
             enableIntrinsicRemember.set(true)
-            enableNonSkippingGroupOptimization.set(true)
             enableExperimentalStrongSkippingMode.set(true)
             val stabilityConfigFile = layout.projectDirectory.file("compose_stability_config.conf").asFile
             if (stabilityConfigFile.exists()) {


### PR DESCRIPTION
Recomposition benchmark shows regression in frame timing metrics when **non skipping group optimization** is enabled.

Non-skipping group optimization enabled:

```
frameDurationCpuMs    P50   3.9,   P90  11.2,   P95  12.6,   P99  14.5
frameOverrunMs        P50  -9.6,   P90   1.8,   P95   2.2,   P99   5.3
```

Non-skipping group optimization disabled:

```
frameDurationCpuMs    P50   3.6,   P90   7.6,   P95  10.0,   P99  12.1
frameOverrunMs        P50  -9.8,   P90  -6.0,   P95  -4.1,   P99   1.6
```