### PR TITLE
Add screenshot tests infra and initial tests.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+**/snapshots/**/*.png filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -97,7 +97,7 @@ jobs:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Run unit tests
-        run: ./gradlew test jvmTest -PslimTests
+        run: ./gradlew test jvmTest
 
   static-analysis:
     name: Static analysis

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -108,6 +108,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -99,6 +99,34 @@ jobs:
       - name: Run unit tests
         run: ./gradlew test jvmTest
 
+  screenshot-tests:
+    name: Screenshot tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      ENABLE_APP_VERSIONING: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '23'
+
+      - uses: kaeawc/setup-tcmalloc@v0.0.1
+
+      - uses: ./.github/actions/cache-build-logic
+
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: Run screenshot tests
+        run: |
+          ./scripts/enforce-git-lfs.sh
+          ./gradlew verifyPaparazzi
+
   static-analysis:
     name: Static analysis
     runs-on: ubuntu-latest
@@ -127,7 +155,7 @@ jobs:
 
   deploy-dev-build:
     name: Upload dev build
-    needs: [ assemble, unit-tests, static-analysis ]
+    needs: [ assemble, unit-tests, screenshot-tests, static-analysis ]
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/android')
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -174,7 +202,7 @@ jobs:
 
   deploy-release-build:
     name: Publish release build to Play Store (internal test track)
-    needs: [ assemble, unit-tests, static-analysis ]
+    needs: [ assemble, unit-tests, screenshot-tests, static-analysis ]
     if: startsWith(github.ref, 'refs/tags/android')
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/android/feature/talking-kotlin-episode/build.gradle.kts
+++ b/android/feature/talking-kotlin-episode/build.gradle.kts
@@ -2,6 +2,7 @@ import com.android.build.api.variant.HasUnitTestBuilder
 
 plugins {
     id("kstreamlined.android.library")
+    id("kstreamlined.android.screenshot-test")
     id("kstreamlined.compose")
     id("kstreamlined.ksp")
 }

--- a/android/feature/talking-kotlin-episode/src/test/java/io/github/reactivecircus/kstreamlined/android/feature/talkingkotlinepisode/component/PlayPauseButtonTest.kt
+++ b/android/feature/talking-kotlin-episode/src/test/java/io/github/reactivecircus/kstreamlined/android/feature/talkingkotlinepisode/component/PlayPauseButtonTest.kt
@@ -1,0 +1,36 @@
+package io.github.reactivecircus.kstreamlined.android.feature.talkingkotlinepisode.component
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.github.reactivecircus.kstreamlined.android.foundation.screenshottesting.tester.SnapshotTester
+import org.junit.Rule
+import org.junit.Test
+
+class PlayPauseButtonTest {
+
+    @get:Rule
+    val snapshotTester = SnapshotTester()
+
+    @Test
+    fun snapshot_PlayPauseButton_paused() {
+        snapshotTester.snapshot {
+            PlayPauseButton(
+                isPlaying = false,
+                onPlayPauseButtonClick = {},
+                modifier = Modifier.padding(8.dp),
+            )
+        }
+    }
+
+    @Test
+    fun snapshot_PlayPauseButton_playing() {
+        snapshotTester.snapshot {
+            PlayPauseButton(
+                isPlaying = true,
+                onPlayPauseButtonClick = {},
+                modifier = Modifier.padding(8.dp),
+            )
+        }
+    }
+}

--- a/android/feature/talking-kotlin-episode/src/test/java/io/github/reactivecircus/kstreamlined/android/feature/talkingkotlinepisode/component/SeekBarTest.kt
+++ b/android/feature/talking-kotlin-episode/src/test/java/io/github/reactivecircus/kstreamlined/android/feature/talkingkotlinepisode/component/SeekBarTest.kt
@@ -1,0 +1,32 @@
+package io.github.reactivecircus.kstreamlined.android.feature.talkingkotlinepisode.component
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component.Surface
+import io.github.reactivecircus.kstreamlined.android.foundation.designsystem.foundation.KSTheme
+import io.github.reactivecircus.kstreamlined.android.foundation.screenshottesting.tester.SnapshotTester
+import org.junit.Rule
+import org.junit.Test
+
+class SeekBarTest {
+
+    @get:Rule
+    val snapshotTester = SnapshotTester()
+
+    @Test
+    fun snapshot_SeekBar() {
+        snapshotTester.snapshot(addSurface = false) {
+            Surface(
+                color = KSTheme.colorScheme.tertiary
+            ) {
+                SeekBar(
+                    modifier = Modifier.padding(8.dp),
+                    positionMillis = 1200_000,
+                    durationMillis = 3000_000,
+                    onPositionChangeFinished = {},
+                )
+            }
+        }
+    }
+}

--- a/android/feature/talking-kotlin-episode/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.talkingkotlinepisode.component_PlayPauseButtonTest_snapshot_PlayPauseButton_paused[Dark].png
+++ b/android/feature/talking-kotlin-episode/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.talkingkotlinepisode.component_PlayPauseButtonTest_snapshot_PlayPauseButton_paused[Dark].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:feea907b3e58075c69d02831c955802bcd9f0c6faad2aee542336e8752652725
+size 3567

--- a/android/feature/talking-kotlin-episode/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.talkingkotlinepisode.component_PlayPauseButtonTest_snapshot_PlayPauseButton_paused[Light].png
+++ b/android/feature/talking-kotlin-episode/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.talkingkotlinepisode.component_PlayPauseButtonTest_snapshot_PlayPauseButton_paused[Light].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98c8474cbedd1e0c5b49eb5c7ae391c20862bcc8c11afbaadf6c16bf170a5720
+size 3336

--- a/android/feature/talking-kotlin-episode/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.talkingkotlinepisode.component_PlayPauseButtonTest_snapshot_PlayPauseButton_playing[Dark].png
+++ b/android/feature/talking-kotlin-episode/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.talkingkotlinepisode.component_PlayPauseButtonTest_snapshot_PlayPauseButton_playing[Dark].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b60b40b7fcf59a0e401860ccf0e43eeb256961242d846d1ca8b3af33322862b
+size 4102

--- a/android/feature/talking-kotlin-episode/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.talkingkotlinepisode.component_PlayPauseButtonTest_snapshot_PlayPauseButton_playing[Light].png
+++ b/android/feature/talking-kotlin-episode/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.talkingkotlinepisode.component_PlayPauseButtonTest_snapshot_PlayPauseButton_playing[Light].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45157eaaa76b4429128830397b3a7a432ae125c64430685b9bc4525a987438c7
+size 3847

--- a/android/feature/talking-kotlin-episode/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.talkingkotlinepisode.component_SeekBarTest_snapshot_SeekBar[Dark].png
+++ b/android/feature/talking-kotlin-episode/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.talkingkotlinepisode.component_SeekBarTest_snapshot_SeekBar[Dark].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:372653dff67832a1c949aa3fc0984fb51b79f984a6f662ba56c7e1a8cdb487d0
+size 6999

--- a/android/feature/talking-kotlin-episode/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.talkingkotlinepisode.component_SeekBarTest_snapshot_SeekBar[Light].png
+++ b/android/feature/talking-kotlin-episode/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.talkingkotlinepisode.component_SeekBarTest_snapshot_SeekBar[Light].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02ce232fb2e14279988a5ed6c40e403467139791723a7ef1a770885a15f87ed0
+size 6939

--- a/android/foundation/designsystem/build.gradle.kts
+++ b/android/foundation/designsystem/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("kstreamlined.android.library")
+    id("kstreamlined.android.screenshot-test")
     id("kstreamlined.compose")
 }
 

--- a/android/foundation/designsystem/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/ButtonTest.kt
+++ b/android/foundation/designsystem/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/ButtonTest.kt
@@ -1,0 +1,25 @@
+package io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.github.reactivecircus.kstreamlined.android.foundation.screenshottesting.tester.SnapshotTester
+import org.junit.Rule
+import org.junit.Test
+
+class ButtonTest {
+
+    @get:Rule
+    val snapshotTester = SnapshotTester()
+
+    @Test
+    fun snapshot_Button() {
+        snapshotTester.snapshot {
+            Button(
+                text = "Button",
+                onClick = {},
+                modifier = Modifier.padding(8.dp),
+            )
+        }
+    }
+}

--- a/android/foundation/designsystem/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/ChipTest.kt
+++ b/android/foundation/designsystem/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/ChipTest.kt
@@ -1,0 +1,32 @@
+package io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.github.reactivecircus.kstreamlined.android.foundation.designsystem.foundation.KSTheme
+import io.github.reactivecircus.kstreamlined.android.foundation.designsystem.foundation.icon.KSIcons
+import io.github.reactivecircus.kstreamlined.android.foundation.screenshottesting.tester.SnapshotTester
+import org.junit.Rule
+import org.junit.Test
+
+class ChipTest {
+
+    @get:Rule
+    val snapshotTester = SnapshotTester()
+
+    @Test
+    fun snapshot_Chip() {
+        snapshotTester.snapshot {
+            Chip(
+                onClick = {},
+                modifier = Modifier.padding(8.dp),
+            ) {
+                Text(
+                    text = "Chip",
+                    style = KSTheme.typography.labelLarge,
+                )
+                Icon(KSIcons.ArrowDown, contentDescription = null)
+            }
+        }
+    }
+}

--- a/android/foundation/designsystem/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/DividerTest.kt
+++ b/android/foundation/designsystem/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/DividerTest.kt
@@ -1,0 +1,55 @@
+package io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.github.reactivecircus.kstreamlined.android.foundation.designsystem.foundation.KSTheme
+import io.github.reactivecircus.kstreamlined.android.foundation.screenshottesting.tester.SnapshotTester
+import org.junit.Rule
+import org.junit.Test
+
+class DividerTest {
+
+    @get:Rule
+    val snapshotTester = SnapshotTester()
+
+    @Test
+    fun snapshot_HorizontalDivider() {
+        snapshotTester.snapshot {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(text = "item 1", style = KSTheme.typography.titleMedium)
+                HorizontalDivider(
+                    modifier = Modifier.width(120.dp),
+                )
+                Text(text = "item 2", style = KSTheme.typography.titleMedium)
+            }
+        }
+    }
+
+    @Test
+    fun snapshot_VerticalDivider() {
+        snapshotTester.snapshot {
+            Row(
+                modifier = Modifier.padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(text = "item 1", style = KSTheme.typography.titleMedium)
+                VerticalDivider(
+                    modifier = Modifier.height(120.dp),
+                )
+                Text(text = "item 2", style = KSTheme.typography.titleMedium)
+            }
+        }
+    }
+}

--- a/android/foundation/designsystem/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/IconButtonTest.kt
+++ b/android/foundation/designsystem/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/IconButtonTest.kt
@@ -1,0 +1,39 @@
+package io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.github.reactivecircus.kstreamlined.android.foundation.designsystem.foundation.icon.KSIcons
+import io.github.reactivecircus.kstreamlined.android.foundation.screenshottesting.tester.SnapshotTester
+import org.junit.Rule
+import org.junit.Test
+
+class IconButtonTest {
+
+    @get:Rule
+    val snapshotTester = SnapshotTester()
+
+    @Test
+    fun snapshot_LargeIconButton() {
+        snapshotTester.snapshot {
+            LargeIconButton(
+                KSIcons.Close,
+                contentDescription = null,
+                onClick = {},
+                modifier = Modifier.padding(8.dp),
+            )
+        }
+    }
+
+    @Test
+    fun snapshot_FilledIconButton() {
+        snapshotTester.snapshot {
+            FilledIconButton(
+                KSIcons.Settings,
+                contentDescription = null,
+                onClick = {},
+                modifier = Modifier.padding(8.dp),
+            )
+        }
+    }
+}

--- a/android/foundation/designsystem/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/NavigationIslandTest.kt
+++ b/android/foundation/designsystem/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/NavigationIslandTest.kt
@@ -1,0 +1,40 @@
+package io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.github.reactivecircus.kstreamlined.android.foundation.designsystem.foundation.icon.Bookmarks
+import io.github.reactivecircus.kstreamlined.android.foundation.designsystem.foundation.icon.KSIcons
+import io.github.reactivecircus.kstreamlined.android.foundation.designsystem.foundation.icon.Kotlin
+import io.github.reactivecircus.kstreamlined.android.foundation.screenshottesting.tester.SnapshotTester
+import org.junit.Rule
+import org.junit.Test
+
+class NavigationIslandTest {
+
+    @get:Rule
+    val snapshotTester = SnapshotTester()
+
+    @Test
+    fun snapshot_NavigationIsland() {
+        snapshotTester.snapshot {
+            NavigationIsland(
+                modifier = Modifier.padding(8.dp),
+            ) {
+                NavigationIslandItem(
+                    selected = true,
+                    icon = KSIcons.Kotlin,
+                    contentDescription = "Home",
+                    onClick = {},
+                )
+                NavigationIslandDivider()
+                NavigationIslandItem(
+                    selected = false,
+                    icon = KSIcons.Bookmarks,
+                    contentDescription = "Saved",
+                    onClick = {},
+                )
+            }
+        }
+    }
+}

--- a/android/foundation/designsystem/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/ProgressIndicatorTest.kt
+++ b/android/foundation/designsystem/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/ProgressIndicatorTest.kt
@@ -1,0 +1,27 @@
+package io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.github.reactivecircus.kstreamlined.android.foundation.screenshottesting.tester.SnapshotTester
+import org.junit.Rule
+import org.junit.Test
+
+class ProgressIndicatorTest {
+
+    @get:Rule
+    val snapshotTester = SnapshotTester()
+
+    @Test
+    fun snapshot_LinearProgressIndicator() {
+        snapshotTester.snapshot {
+            LinearProgressIndicator(
+                progress = { 0.5f },
+                modifier = Modifier
+                    .width(200.dp)
+                    .padding(8.dp),
+            )
+        }
+    }
+}

--- a/android/foundation/designsystem/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/TopNavBarTest.kt
+++ b/android/foundation/designsystem/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/TopNavBarTest.kt
@@ -1,0 +1,87 @@
+package io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component
+
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import io.github.reactivecircus.kstreamlined.android.foundation.designsystem.foundation.KSTheme
+import io.github.reactivecircus.kstreamlined.android.foundation.designsystem.foundation.icon.KSIcons
+import io.github.reactivecircus.kstreamlined.android.foundation.screenshottesting.tester.SnapshotTester
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+class TopNavBarTest {
+
+    @get:Rule
+    val snapshotTester = SnapshotTester()
+
+    @Test
+    fun snapshot_TopNavBar_default() {
+        snapshotTester.snapshot {
+            SharedTransitionLayout {
+                TopNavBar(
+                    title = "Title",
+                    actions = {
+                        FilledIconButton(
+                            KSIcons.Settings,
+                            contentDescription = null,
+                            onClick = {},
+                        )
+                    },
+                )
+            }
+        }
+    }
+
+    @Test
+    fun snapshot_TopNavBar_withBottomRow() {
+        snapshotTester.snapshot {
+            SharedTransitionLayout {
+                TopNavBar(
+                    title = "Title",
+                    actions = {
+                        FilledIconButton(
+                            KSIcons.Settings,
+                            contentDescription = null,
+                            onClick = {},
+                        )
+                    },
+                    bottomRow = {
+                        Chip(
+                            onClick = {},
+                            contentColor = KSTheme.colorScheme.primary,
+                        ) {
+                            Text(
+                                text = "Button".uppercase(),
+                                style = KSTheme.typography.labelMedium.copy(
+                                    fontWeight = FontWeight.ExtraBold,
+                                    letterSpacing = 0.sp,
+                                )
+                            )
+                            Icon(KSIcons.ArrowDown, contentDescription = null)
+                        }
+                    }
+                )
+            }
+        }
+    }
+
+    @Test
+    fun snapshot_TopNavBar_withNavigationIcon() {
+        snapshotTester.snapshot {
+            SharedTransitionLayout {
+                TopNavBar(
+                    title = "Title",
+                    navigationIcon = {
+                        LargeIconButton(
+                            KSIcons.Close,
+                            contentDescription = null,
+                            onClick = {},
+                        )
+                    },
+                )
+            }
+        }
+    }
+}

--- a/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_ButtonTest_snapshot_Button[Dark].png
+++ b/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_ButtonTest_snapshot_Button[Dark].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6314e6b5ffc2051ade98977ea3d0a52f4aba612692c332ce1f01877ad9215ed9
+size 3625

--- a/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_ButtonTest_snapshot_Button[Light].png
+++ b/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_ButtonTest_snapshot_Button[Light].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f97d600f20248e5702ed4cc396d57de72d67dc71ff0f526d912fc419aa2ff78
+size 3392

--- a/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_ChipTest_snapshot_Chip[Dark].png
+++ b/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_ChipTest_snapshot_Chip[Dark].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a66f81792a296a8ee8ca3d66ddcefbc4639fe5a5f40337fb83e6266b257ce16c
+size 3442

--- a/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_ChipTest_snapshot_Chip[Light].png
+++ b/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_ChipTest_snapshot_Chip[Light].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:486ffa09f11a66320a0d63c755df7489c49d15ce8bd5e2a0f963b72e0578b1f4
+size 3415

--- a/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_DividerTest_snapshot_HorizontalDivider[Dark].png
+++ b/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_DividerTest_snapshot_HorizontalDivider[Dark].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e58c5111c5b4969dd596af3cedd2c5f20523859cc8251e01a87efbf4865735c1
+size 4263

--- a/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_DividerTest_snapshot_HorizontalDivider[Light].png
+++ b/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_DividerTest_snapshot_HorizontalDivider[Light].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f237fe2c9cdfc1eb9485cbe4fd53df635a1fec3298756f924fde2f9a18b21ac1
+size 4248

--- a/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_DividerTest_snapshot_VerticalDivider[Dark].png
+++ b/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_DividerTest_snapshot_VerticalDivider[Dark].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49010c82e2e94bedec95c553fcfe5e4a3786fbbf77ffd158dd21ac17d5bd14ff
+size 3938

--- a/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_DividerTest_snapshot_VerticalDivider[Light].png
+++ b/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_DividerTest_snapshot_VerticalDivider[Light].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83b1e7ea7e773150432b96caff7000351ff4bdf4a8a86ca5ece1edb692c62702
+size 3923

--- a/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_IconButtonTest_snapshot_FilledIconButton[Dark].png
+++ b/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_IconButtonTest_snapshot_FilledIconButton[Dark].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb502902671f032018cc05389f730129258a74b1ffa64e2555020df7c1071319
+size 2360

--- a/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_IconButtonTest_snapshot_FilledIconButton[Light].png
+++ b/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_IconButtonTest_snapshot_FilledIconButton[Light].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5364676c0568a30fdf79a9f3e5f0943182f88d37c8ed105dcb3e70639e3069aa
+size 2350

--- a/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_IconButtonTest_snapshot_LargeIconButton[Dark].png
+++ b/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_IconButtonTest_snapshot_LargeIconButton[Dark].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0654fdd804b9fe23bf80c5d8154191d09df7d849ba87828b4cfb5e606bb0797
+size 805

--- a/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_IconButtonTest_snapshot_LargeIconButton[Light].png
+++ b/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_IconButtonTest_snapshot_LargeIconButton[Light].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7d4be5df0f6c1c338bc328ba15837fd741e64b039645b57512e3ca2d21980a1
+size 805

--- a/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_NavigationIslandTest_snapshot_NavigationIsland[Dark].png
+++ b/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_NavigationIslandTest_snapshot_NavigationIsland[Dark].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3b1b125fce06d387deeb56bb656e6385b78d678fbccd5680474aa4e125e21f6
+size 5505

--- a/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_NavigationIslandTest_snapshot_NavigationIsland[Light].png
+++ b/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_NavigationIslandTest_snapshot_NavigationIsland[Light].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f137de989de27f6182c158fc2ca07831003abfda79a45fbfebd3b75fcfc8009a
+size 8874

--- a/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_ProgressIndicatorTest_snapshot_LinearProgressIndicator[Dark].png
+++ b/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_ProgressIndicatorTest_snapshot_LinearProgressIndicator[Dark].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7506ee12ba57d61f0cc7303a78523e3464dca9a9758ab7a29c0b2221466f2d11
+size 721

--- a/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_ProgressIndicatorTest_snapshot_LinearProgressIndicator[Light].png
+++ b/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_ProgressIndicatorTest_snapshot_LinearProgressIndicator[Light].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4219388d91025036abd995c67a3d65717ab4f4fd418e342af431c7c699ba23a4
+size 675

--- a/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_TopNavBarTest_snapshot_TopNavBar_default[Dark].png
+++ b/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_TopNavBarTest_snapshot_TopNavBar_default[Dark].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37aac60c5b5ef991b831e7f27f23a0ac2d4645bbc6ec53963c1265ab6d80ce80
+size 11520

--- a/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_TopNavBarTest_snapshot_TopNavBar_default[Light].png
+++ b/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_TopNavBarTest_snapshot_TopNavBar_default[Light].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02dc58149b59a3a54c615eca50e9d74ca352640b5e9d9c948b4459084071a91b
+size 11007

--- a/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_TopNavBarTest_snapshot_TopNavBar_withBottomRow[Dark].png
+++ b/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_TopNavBarTest_snapshot_TopNavBar_withBottomRow[Dark].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbec4e9244a325c36fbdb0c2bfc90449dea3af6ae6b4d353a29d9ae1b0d13be6
+size 17167

--- a/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_TopNavBarTest_snapshot_TopNavBar_withBottomRow[Light].png
+++ b/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_TopNavBarTest_snapshot_TopNavBar_withBottomRow[Light].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e337088706036d549273276b6107557b0ce85e481227af47e11c833d6a1d20e3
+size 16196

--- a/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_TopNavBarTest_snapshot_TopNavBar_withNavigationIcon[Dark].png
+++ b/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_TopNavBarTest_snapshot_TopNavBar_withNavigationIcon[Dark].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1fa6961b43019d6b995450d679ba76e80a508a00aa1131b8b1c45cb5f1791da8
+size 9354

--- a/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_TopNavBarTest_snapshot_TopNavBar_withNavigationIcon[Light].png
+++ b/android/foundation/designsystem/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component_TopNavBarTest_snapshot_TopNavBar_withNavigationIcon[Light].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6d5d99df2f10b5d7c791e5623274959df65500dd94a9d7f71c0cac3449b84b3
+size 8847

--- a/android/foundation/screenshot-testing/paparazzi/build.gradle.kts
+++ b/android/foundation/screenshot-testing/paparazzi/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    id("kstreamlined.kotlin.jvm")
+}
+
+dependencies {
+    // Paparazzi
+    implementation(libs.paparazzi)
+}

--- a/android/foundation/screenshot-testing/paparazzi/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/screenshottesting/paparazzi/PaparazziRule.kt
+++ b/android/foundation/screenshot-testing/paparazzi/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/screenshottesting/paparazzi/PaparazziRule.kt
@@ -1,0 +1,102 @@
+package io.github.reactivecircus.kstreamlined.android.foundation.screenshottesting.paparazzi
+
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.HtmlReportWriter
+import app.cash.paparazzi.PaparazziSdk
+import app.cash.paparazzi.Snapshot
+import app.cash.paparazzi.SnapshotHandler
+import app.cash.paparazzi.SnapshotVerifier
+import app.cash.paparazzi.TestName
+import app.cash.paparazzi.detectEnvironment
+import com.android.ide.common.rendering.api.SessionParams
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import java.util.Date
+
+public abstract class PaparazziRule(
+    private val deviceConfig: DeviceConfig,
+    private val theme: String,
+    private val renderingMode: SessionParams.RenderingMode,
+    private val compileSdkVersion: Int,
+    maxPercentDifference: Double,
+) : TestRule {
+    protected lateinit var sdk: PaparazziSdk
+    protected lateinit var frameHandler: SnapshotHandler.FrameHandler
+    private var testName: TestName? = null
+
+    private val snapshotHandler: SnapshotHandler = determineHandler(maxPercentDifference)
+
+    override fun apply(base: Statement, description: Description): Statement =
+        object : Statement() {
+            override fun evaluate() {
+                Description.createTestDescription(
+                    description.className,
+                    description.methodName
+                )
+                sdk = PaparazziSdk(
+                    environment = detectEnvironment().copy(compileSdkVersion = compileSdkVersion),
+                    deviceConfig = deviceConfig,
+                    theme = theme,
+                    renderingMode = renderingMode,
+                    appCompatEnabled = false,
+                    onNewFrame = { frameHandler.handle(it) },
+                )
+                sdk.setup()
+                prepare(description)
+                try {
+                    base.evaluate()
+                } finally {
+                    close()
+                }
+            }
+        }
+
+    private fun prepare(description: Description) {
+        testName = description.toTestName()
+        sdk.prepare()
+    }
+
+    private fun close() {
+        testName = null
+        sdk.teardown()
+        snapshotHandler.close()
+    }
+
+    protected fun createFrameHandler(
+        name: String? = null,
+        testNameSuffix: String? = null,
+        frameCount: Int = 1,
+        fps: Int = -1,
+    ): SnapshotHandler.FrameHandler {
+        val snapshot = Snapshot(
+            name = name,
+            testName = testName!!.copy(
+                methodName = testNameSuffix?.let {
+                    testName!!.methodName + "[$testNameSuffix]"
+                } ?: testName!!.methodName
+            ),
+            timestamp = Date(),
+        )
+        return snapshotHandler.newFrameHandler(snapshot, frameCount, fps)
+    }
+
+    private fun Description.toTestName(): TestName {
+        val fullQualifiedName = className
+        val packageName = fullQualifiedName.substringBeforeLast('.', missingDelimiterValue = "")
+        val className = fullQualifiedName.substringAfterLast('.')
+        return TestName(packageName, className, methodName)
+    }
+
+    private companion object {
+        private val isVerifying: Boolean =
+            System.getProperty("paparazzi.test.verify")?.toBoolean() == true
+
+        private fun determineHandler(maxPercentDifference: Double): SnapshotHandler =
+            if (isVerifying) {
+                SnapshotVerifier(maxPercentDifference)
+            } else {
+                HtmlReportWriter()
+            }
+    }
+}

--- a/android/foundation/screenshot-testing/paparazzi/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/screenshottesting/paparazzi/PaparazziRule.kt
+++ b/android/foundation/screenshot-testing/paparazzi/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/screenshottesting/paparazzi/PaparazziRule.kt
@@ -14,6 +14,10 @@ import org.junit.runner.Description
 import org.junit.runners.model.Statement
 import java.util.Date
 
+/**
+ * Adapted from https://github.com/cashapp/paparazzi/blob/master/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+ * to support more opinionated test rule implementation.
+ */
 public abstract class PaparazziRule(
     private val deviceConfig: DeviceConfig,
     private val theme: String,

--- a/android/foundation/screenshot-testing/tester/build.gradle.kts
+++ b/android/foundation/screenshot-testing/tester/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    id("kstreamlined.android.library")
+    id("kstreamlined.compose")
+}
+
+android {
+    namespace = "io.github.reactivecircus.kstreamlined.android.foundation.screenshottesting.tester"
+}
+
+dependencies {
+    api(project(":foundation:screenshot-testing:paparazzi"))
+    implementation(project(":foundation:designsystem"))
+
+    // AndroidX
+    implementation(libs.androidx.compose.foundation)
+
+    // Paparazzi
+    implementation(libs.paparazzi)
+}

--- a/android/foundation/screenshot-testing/tester/src/main/AndroidManifest.xml
+++ b/android/foundation/screenshot-testing/tester/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/android/foundation/screenshot-testing/tester/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/screenshottesting/tester/SnapshotTester.kt
+++ b/android/foundation/screenshot-testing/tester/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/screenshottesting/tester/SnapshotTester.kt
@@ -1,0 +1,41 @@
+package io.github.reactivecircus.kstreamlined.android.foundation.screenshottesting.tester
+
+import androidx.compose.runtime.Composable
+import app.cash.paparazzi.DeviceConfig.Companion.PIXEL_6
+import com.android.ide.common.rendering.api.SessionParams
+import io.github.reactivecircus.kstreamlined.android.foundation.designsystem.component.Surface
+import io.github.reactivecircus.kstreamlined.android.foundation.designsystem.foundation.KSTheme
+import io.github.reactivecircus.kstreamlined.android.foundation.screenshottesting.paparazzi.PaparazziRule
+
+public class SnapshotTester(
+    maxPercentDifference: Double = 0.1,
+) : PaparazziRule(
+    deviceConfig = PIXEL_6,
+    theme = "android:Theme.Material.Light.NoActionBar",
+    renderingMode = SessionParams.RenderingMode.SHRINK,
+    compileSdkVersion = 34,
+    maxPercentDifference = maxPercentDifference,
+) {
+    public fun snapshot(
+        addSurface: Boolean = true,
+        content: @Composable () -> Unit,
+    ) {
+        arrayOf(false, true).forEach { darkTheme ->
+            val testNameSuffix = if (darkTheme) "Dark" else "Light"
+            createFrameHandler(testNameSuffix = testNameSuffix).use { handler ->
+                frameHandler = handler
+                sdk.snapshot {
+                    KSTheme(darkTheme) {
+                        if (addSurface) {
+                            Surface {
+                                content()
+                            }
+                        } else {
+                            content()
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation(libs.plugin.detekt)
     implementation(libs.plugin.agp)
     implementation(libs.plugin.appVersioning)
+    implementation(libs.plugin.paparazzi)
     implementation(libs.plugin.hilt)
     implementation(libs.plugin.apollo)
     implementation(libs.plugin.wire)
@@ -81,6 +82,10 @@ gradlePlugin {
             id = "kstreamlined.android.test"
             implementationClass = "io.github.reactivecircus.kstreamlined.buildlogic.convention.AndroidTestConventionPlugin"
         }
+        register("androidScreenshotTest") {
+            id = "kstreamlined.android.screenshot-test"
+            implementationClass = "io.github.reactivecircus.kstreamlined.buildlogic.convention.AndroidScreenshotTestConventionPlugin"
+        }
         register("kmpCommon") {
             id = "kstreamlined.kmp.common"
             implementationClass = "io.github.reactivecircus.kstreamlined.buildlogic.convention.KMPCommonConventionPlugin"
@@ -96,6 +101,10 @@ gradlePlugin {
         register("kmpTest") {
             id = "kstreamlined.kmp.test"
             implementationClass = "io.github.reactivecircus.kstreamlined.buildlogic.convention.KMPTestConventionPlugin"
+        }
+        register("kotlinJvm") {
+            id = "kstreamlined.kotlin.jvm"
+            implementationClass = "io.github.reactivecircus.kstreamlined.buildlogic.convention.KotlinJvmConventionPlugin"
         }
         register("compose") {
             id = "kstreamlined.compose"

--- a/build-logic/src/main/kotlin/buildEnvironment.kt
+++ b/build-logic/src/main/kotlin/buildEnvironment.kt
@@ -7,6 +7,16 @@ val Project.isCiBuild: Boolean
 val Project.isIdeBuild: Boolean
     get() = providers.systemProperty("idea.active").orNull == "true"
 
+val Project.runningPaparazzi: Boolean
+    get() = gradle.startParameter.taskNames.any {
+        it.substringAfterLast(":").contains("paparazzi", ignoreCase = true)
+    }
+
+val Project.runningCheck: Boolean
+    get() = gradle.startParameter.taskNames.any {
+        it.substringAfterLast(":").equals("check", ignoreCase = true)
+    }
+
 val Project.isGeneratingBaselineProfile: Boolean
     get() = gradle.startParameter.taskNames.any {
         it.contains("generateBaselineProfile", ignoreCase = true)

--- a/build-logic/src/main/kotlin/io/github/reactivecircus/kstreamlined/buildlogic/androidBuildLogic.kt
+++ b/build-logic/src/main/kotlin/io/github/reactivecircus/kstreamlined/buildlogic/androidBuildLogic.kt
@@ -99,13 +99,13 @@ internal fun ApplicationAndroidComponentsExtension.configureAndroidApplicationVa
  */
 internal fun LibraryAndroidComponentsExtension.configureAndroidLibraryVariants() {
     beforeVariants {
+        // only enable release build variant for the Android library project
+        it.enable = it.buildType == "release"
+
         // disable unit tests by default
         (it as HasUnitTestBuilder).enableUnitTest = false
 
         // disable android tests by default
         it.androidTest.enable = false
-
-        // only enable release build variant for the Android library project
-        it.enable = it.buildType == "release"
     }
 }

--- a/build-logic/src/main/kotlin/io/github/reactivecircus/kstreamlined/buildlogic/convention/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/reactivecircus/kstreamlined/buildlogic/convention/AndroidApplicationConventionPlugin.kt
@@ -7,7 +7,6 @@ import io.github.reactivecircus.kstreamlined.buildlogic.configureAndroidApplicat
 import io.github.reactivecircus.kstreamlined.buildlogic.configureCommonAndroidExtension
 import io.github.reactivecircus.kstreamlined.buildlogic.configureDetekt
 import io.github.reactivecircus.kstreamlined.buildlogic.configureKotlin
-import io.github.reactivecircus.kstreamlined.buildlogic.configureSlimTests
 import io.github.reactivecircus.kstreamlined.buildlogic.configureTest
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -35,7 +34,6 @@ internal class AndroidApplicationConventionPlugin : Plugin<Project> {
         }
 
         configureTest()
-        configureSlimTests()
         configureDetekt()
     }
 }

--- a/build-logic/src/main/kotlin/io/github/reactivecircus/kstreamlined/buildlogic/convention/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/reactivecircus/kstreamlined/buildlogic/convention/AndroidLibraryConventionPlugin.kt
@@ -6,7 +6,6 @@ import io.github.reactivecircus.kstreamlined.buildlogic.configureAndroidLibraryV
 import io.github.reactivecircus.kstreamlined.buildlogic.configureCommonAndroidExtension
 import io.github.reactivecircus.kstreamlined.buildlogic.configureDetekt
 import io.github.reactivecircus.kstreamlined.buildlogic.configureKotlin
-import io.github.reactivecircus.kstreamlined.buildlogic.configureSlimTests
 import io.github.reactivecircus.kstreamlined.buildlogic.configureTest
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -33,7 +32,6 @@ internal class AndroidLibraryConventionPlugin : Plugin<Project> {
         }
 
         configureTest()
-        configureSlimTests()
         configureDetekt()
     }
 }

--- a/build-logic/src/main/kotlin/io/github/reactivecircus/kstreamlined/buildlogic/convention/AndroidScreenshotTestConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/reactivecircus/kstreamlined/buildlogic/convention/AndroidScreenshotTestConventionPlugin.kt
@@ -1,0 +1,60 @@
+package io.github.reactivecircus.kstreamlined.buildlogic.convention
+
+import app.cash.paparazzi.gradle.PrepareResourcesTask
+import com.android.build.api.variant.ApplicationAndroidComponentsExtension
+import com.android.build.api.variant.HasUnitTestBuilder
+import com.android.build.api.variant.LibraryAndroidComponentsExtension
+import isIdeBuild
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.testing.Test
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.withType
+import runningCheck
+import runningPaparazzi
+
+internal class AndroidScreenshotTestConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) = with(target) {
+        pluginManager.apply("app.cash.paparazzi")
+        pluginManager.withPlugin("app.cash.paparazzi") {
+            tasks.withType<Test>().configureEach {
+                if (!runningCheck) {
+                    // skip running regular unit tests when running one of the paparazzi tasks
+                    // skip running paparazzi tests when running regular unit tests
+                    filter {
+                        if (runningPaparazzi) {
+                            includePatterns += "*.snapshot*"
+                        } else {
+                            excludePatterns += "*.snapshot*"
+                        }
+                    }
+                }
+            }
+            tasks.withType<PrepareResourcesTask>().configureEach {
+                enabled = runningCheck || runningPaparazzi
+            }
+            tasks.named("check").configure {
+                dependsOn("verifyPaparazzi")
+            }
+        }
+
+        dependencies.add("testImplementation", project(":foundation:screenshot-testing:tester"))
+
+        if (runningCheck || runningPaparazzi || isIdeBuild) {
+            pluginManager.withPlugin("com.android.library") {
+                extensions.configure<LibraryAndroidComponentsExtension> {
+                    beforeVariants {
+                        (it as HasUnitTestBuilder).enableUnitTest = true
+                    }
+                }
+            }
+            pluginManager.withPlugin("com.android.application") {
+                extensions.configure<ApplicationAndroidComponentsExtension> {
+                    beforeVariants {
+                        (it as HasUnitTestBuilder).enableUnitTest = true
+                    }
+                }
+            }
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/io/github/reactivecircus/kstreamlined/buildlogic/convention/KotlinJvmConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/reactivecircus/kstreamlined/buildlogic/convention/KotlinJvmConventionPlugin.kt
@@ -1,0 +1,23 @@
+package io.github.reactivecircus.kstreamlined.buildlogic.convention
+
+import io.github.reactivecircus.kstreamlined.buildlogic.configureDetekt
+import io.github.reactivecircus.kstreamlined.buildlogic.configureKotlin
+import io.github.reactivecircus.kstreamlined.buildlogic.configureTest
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
+
+internal class KotlinJvmConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) = with(target) {
+        pluginManager.apply("org.jetbrains.kotlin.jvm")
+        pluginManager.apply("com.android.lint")
+
+        extensions.configure<KotlinJvmProjectExtension> {
+            configureKotlin(target)
+        }
+
+        configureTest()
+        configureDetekt()
+    }
+}

--- a/build-logic/src/main/kotlin/io/github/reactivecircus/kstreamlined/buildlogic/kotlinBuildLogic.kt
+++ b/build-logic/src/main/kotlin/io/github/reactivecircus/kstreamlined/buildlogic/kotlinBuildLogic.kt
@@ -1,6 +1,8 @@
 package io.github.reactivecircus.kstreamlined.buildlogic
 
+import org.gradle.api.JavaVersion
 import org.gradle.api.Project
+import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
@@ -22,6 +24,10 @@ internal fun KotlinProjectExtension.configureKotlin(
                 "-Xconsistent-data-class-copy-visibility",
             )
         }
+    }
+    target.tasks.withType<JavaCompile>().configureEach {
+        sourceCompatibility = JavaVersion.VERSION_17.toString()
+        targetCompatibility = JavaVersion.VERSION_17.toString()
     }
     sourceSets.configureEach {
         languageSettings {

--- a/build-logic/src/main/kotlin/io/github/reactivecircus/kstreamlined/buildlogic/unitTestBuildLogic.kt
+++ b/build-logic/src/main/kotlin/io/github/reactivecircus/kstreamlined/buildlogic/unitTestBuildLogic.kt
@@ -2,13 +2,9 @@
 
 package io.github.reactivecircus.kstreamlined.buildlogic
 
-import com.android.build.api.variant.ApplicationAndroidComponentsExtension
-import com.android.build.api.variant.HasUnitTestBuilder
-import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import org.gradle.api.Project
 import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.logging.TestLogEvent
-import org.gradle.kotlin.dsl.findByType
 import org.gradle.kotlin.dsl.withType
 
 /**
@@ -22,47 +18,3 @@ internal fun Project.configureTest() {
         }
     }
 }
-
-/**
- * When the "slimTests" project property is provided, disable the unit test tasks
- * on `release`, 'benchmark' build types and `demo`, `mock`, and `prod` product flavors to avoid running the same tests repeatedly
- * in different build variants.
- *
- * Examples:
- * `./gradlew test -PslimTests` will run unit tests for `devDebug` and `debug` build variants
- * in Android App and Library projects, and all tests in JVM projects and Kotlin Multiplatform projects.
- */
-internal fun Project.configureSlimTests() {
-    if (providers.gradleProperty(SlimTestsProperty).isPresent) {
-        // disable unit test tasks on the release, benchmark build types for Android Library projects
-        extensions.findByType<LibraryAndroidComponentsExtension>()?.run {
-            beforeVariants(selector().withBuildType("release")) {
-                (it as HasUnitTestBuilder).enableUnitTest = false
-            }
-            beforeVariants(selector().withBuildType("benchmark")) {
-                (it as HasUnitTestBuilder).enableUnitTest = false
-            }
-        }
-
-        // disable unit test tasks on the release, benchmark build types and all non-dev flavors for Android Application projects.
-        extensions.findByType<ApplicationAndroidComponentsExtension>()?.run {
-            beforeVariants(selector().withBuildType("release")) {
-                (it as HasUnitTestBuilder).enableUnitTest = false
-            }
-            beforeVariants(selector().withBuildType("benchmark")) {
-                (it as HasUnitTestBuilder).enableUnitTest = false
-            }
-            beforeVariants(selector().withFlavor(FlavorDimensions.Environment to ProductFlavors.Demo)) {
-                (it as HasUnitTestBuilder).enableUnitTest = false
-            }
-            beforeVariants(selector().withFlavor(FlavorDimensions.Environment to ProductFlavors.Mock)) {
-                (it as HasUnitTestBuilder).enableUnitTest = false
-            }
-            beforeVariants(selector().withFlavor(FlavorDimensions.Environment to ProductFlavors.Prod)) {
-                (it as HasUnitTestBuilder).enableUnitTest = false
-            }
-        }
-    }
-}
-
-private const val SlimTestsProperty = "slimTests"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ androidGradlePlugin = "8.10.0-alpha07"
 gradle-develocityPlugin = "3.19.1"
 gradle-toolchainsResolverPlugin = "0.9.0"
 appVersioning = "1.3.2"
+paparazzi = "1.3.5"
 apollo = "4.1.1"
 apollo-adapters = "0.0.4"
 apollo-mockserver = "0.1.0"
@@ -65,6 +66,7 @@ plugin-powerAssert = { module = "org.jetbrains.kotlin:kotlin-power-assert", vers
 plugin-ksp = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "ksp"}
 plugin-agp = { module = "com.android.tools.build:gradle", version.ref = "androidGradlePlugin"}
 plugin-appVersioning = { module = "io.github.reactivecircus.appversioning:app-versioning-gradle-plugin", version.ref = "appVersioning"}
+plugin-paparazzi = { module = "app.cash.paparazzi:paparazzi-gradle-plugin", version.ref = "paparazzi" }
 plugin-hilt = { module = "com.google.dagger:hilt-android-gradle-plugin", version.ref = "hilt"}
 plugin-apollo = { module = "com.apollographql.apollo:apollo-gradle-plugin", version.ref = "apollo"}
 plugin-wire = { module = "com.squareup.wire:wire-gradle-plugin", version.ref = "wire"}
@@ -131,6 +133,7 @@ sqldelight-coroutinesExtensions = { module = "app.cash.sqldelight:coroutines-ext
 sqldelight-androidDriver = { module = "app.cash.sqldelight:android-driver", version.ref = "sqldelight" }
 sqldelight-nativeDriver = { module = "app.cash.sqldelight:native-driver", version.ref = "sqldelight" }
 sqldelight-sqliteDriver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
+paparazzi = { module = "app.cash.paparazzi:paparazzi", version.ref = "paparazzi" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
 crashKios = { module = "co.touchlab:crashkios", version.ref = "crashKios" }

--- a/scripts/enforce-git-lfs.sh
+++ b/scripts/enforce-git-lfs.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# compares files that match .gitattributes filter to those actually tracked by git-lfs
+diff <(git ls-files ':(attr:filter=lfs)' | sort) <(git lfs ls-files -n | sort) >/dev/null
+
+result=$?
+if [[ $result -ne 0 ]]; then
+  echo >&2 "This remote has detected files committed without using Git LFS. Run 'brew install git-lfs && git lfs install' to install it and re-commit your files.";
+  exit 1;
+fi

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -93,6 +93,8 @@ if (!isXCFrameworkBuild) {
     includeProject(":foundation:common-ui:feed", "android/foundation/common-ui/feed")
     includeProject(":foundation:designsystem", "android/foundation/designsystem")
     includeProject(":foundation:compose-utils", "android/foundation/compose-utils")
+    includeProject(":foundation:screenshot-testing:tester", "android/foundation/screenshot-testing/tester")
+    includeProject(":foundation:screenshot-testing:paparazzi", "android/foundation/screenshot-testing/paparazzi")
     includeProject(":foundation:scheduled-work", "android/foundation/scheduled-work")
 }
 


### PR DESCRIPTION
- add custom Junit rule to integrate with `PaparazziSdk` and custom theme, and automatically generate snapshots for both light and dark variants
- add `screenshot-test` and `kotlin.jvm` convention plugins
- clean up unit test build logic
- setup git lfs and CI

Start adding snapshots for `:foundation:designsystem` and `:feature:talking-kotlin-episode`.