### PR TITLE
Support using `TestParameterInjector` instead of `ThemeVariantInjector` for parameterized tests.

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -227,23 +227,17 @@ dependencies {
     demoImplementation(project(":kmp:remote:edge"))
     devImplementation(project(":kmp:remote:cloud"))
     prodImplementation(project(":kmp:remote:cloud"))
-
     implementation(project(":feature:common"))
     implementation(project(":feature:content-viewer"))
     implementation(project(":feature:home"))
     implementation(project(":feature:kotlin-weekly-issue"))
     implementation(project(":feature:saved-for-later"))
     implementation(project(":feature:talking-kotlin-episode"))
-
     implementation(project(":foundation:scheduled-work"))
-
     baselineProfile(project(":benchmark"))
 
-    // Firebase
     releaseImplementation(libs.firebase.perf)
     implementation(libs.firebase.crashlytics)
-
-    // AndroidX
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.coreSplashscreen)
@@ -251,22 +245,12 @@ dependencies {
     implementation(libs.androidx.compose.runtime.tracing)
     implementation(libs.androidx.hilt.work)
     implementation(libs.androidx.tracing)
-
-    // Hilt
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
-
-    // OkHttp
     implementation(libs.okhttp)
-
-    // Image loading
     implementation(libs.coil.svg)
     implementation(libs.coil.network)
-
-    // SQLDelight
     implementation(libs.sqldelight.androidDriver)
-
-    // LeakCanary
     debugImplementation(libs.leakcanary.android)
     implementation(libs.leakcanary.plumber)
 }

--- a/android/feature/common/build.gradle.kts
+++ b/android/feature/common/build.gradle.kts
@@ -12,7 +12,6 @@ android {
 dependencies {
     api(project(":foundation:designsystem"))
 
-    // AndroidX
     api(libs.androidx.core)
     api(libs.androidx.compose.foundation)
     api(libs.androidx.compose.ui.tooling)
@@ -20,13 +19,7 @@ dependencies {
     api(libs.androidx.lifecycle.viewmodelCompose)
     api(libs.androidx.hilt.navigationCompose)
     implementation(libs.androidx.browser)
-
-    // Image loading
     api(libs.coil.compose)
-
-    // Logging
     api(libs.kermit)
-
-    // Coroutines
     api(libs.kotlinx.coroutines.core)
 }

--- a/android/feature/content-viewer/build.gradle.kts
+++ b/android/feature/content-viewer/build.gradle.kts
@@ -16,11 +16,8 @@ dependencies {
     implementation(project(":kmp:feed-datasource"))
     implementation(project(":kmp:presentation:content-viewer"))
 
-    // AndroidX
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.tracing)
-
-    // Hilt
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
 }

--- a/android/feature/home/build.gradle.kts
+++ b/android/feature/home/build.gradle.kts
@@ -18,11 +18,8 @@ dependencies {
     implementation(project(":kmp:feed-sync:common"))
     implementation(project(":kmp:presentation:home"))
 
-    // AndroidX
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.tracing)
-
-    // Hilt
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
 }

--- a/android/feature/kotlin-weekly-issue/build.gradle.kts
+++ b/android/feature/kotlin-weekly-issue/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("kstreamlined.android.library")
+    id("kstreamlined.android.screenshot-test")
     id("kstreamlined.compose")
     id("kstreamlined.ksp")
 }
@@ -16,10 +17,9 @@ dependencies {
     implementation(project(":kmp:feed-datasource"))
     implementation(project(":kmp:presentation:kotlin-weekly-issue"))
 
-    // AndroidX
     implementation(libs.androidx.tracing)
-
-    // Hilt
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
+
+    testImplementation(libs.testParameterInjector)
 }

--- a/android/feature/kotlin-weekly-issue/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/feature/kotlinweeklyissue/KotlinWeeklyIssueScreen.kt
+++ b/android/feature/kotlin-weekly-issue/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/feature/kotlinweeklyissue/KotlinWeeklyIssueScreen.kt
@@ -108,7 +108,6 @@ public fun SharedTransitionScope.KotlinWeeklyIssueScreen(
 
 @Composable
 internal fun SharedTransitionScope.KotlinWeeklyIssueScreen(
-    animatedVisibilityScope: AnimatedVisibilityScope,
     topBarBoundsKey: String,
     titleElementKey: String,
     id: String,
@@ -119,6 +118,7 @@ internal fun SharedTransitionScope.KotlinWeeklyIssueScreen(
     uiState: KotlinWeeklyIssueUiState,
     eventSink: (KotlinWeeklyIssueUiEvent) -> Unit,
     modifier: Modifier = Modifier,
+    animatedVisibilityScope: AnimatedVisibilityScope? = null,
 ) {
     Column(
         modifier = modifier
@@ -144,7 +144,7 @@ internal fun SharedTransitionScope.KotlinWeeklyIssueScreen(
                 AnimatedVisibility(uiState is KotlinWeeklyIssueUiState.Content) {
                     Row {
                         val contentUrl = (uiState as? KotlinWeeklyIssueUiState.Content)?.contentUrl.orEmpty()
-                        val saved = (uiState as? KotlinWeeklyIssueUiState.Content)?.savedForLater ?: false
+                        val saved = (uiState as? KotlinWeeklyIssueUiState.Content)?.savedForLater == true
                         FilledIconButton(
                             KSIcons.Share,
                             contentDescription = null,

--- a/android/feature/kotlin-weekly-issue/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/kotlinweeklyissue/component/IssueGroupUiTest.kt
+++ b/android/feature/kotlin-weekly-issue/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/kotlinweeklyissue/component/IssueGroupUiTest.kt
@@ -1,0 +1,27 @@
+package io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component
+
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import io.github.reactivecircus.kstreamlined.android.foundation.screenshottesting.tester.SnapshotTester
+import io.github.reactivecircus.kstreamlined.android.foundation.screenshottesting.tester.ThemeVariant
+import io.github.reactivecircus.kstreamlined.kmp.model.feed.KotlinWeeklyIssueItem
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(TestParameterInjector::class)
+class IssueGroupUiTest {
+
+    @get:Rule
+    val snapshotTester = SnapshotTester()
+
+    @Test
+    fun snapshot_IssueGroupUi(
+        @TestParameter group: KotlinWeeklyIssueItem.Group,
+        @TestParameter themeVariant: ThemeVariant,
+    ) {
+        snapshotTester.snapshot(themeVariant = themeVariant) {
+            IssueGroupUi(group = group)
+        }
+    }
+}

--- a/android/feature/kotlin-weekly-issue/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/kotlinweeklyissue/component/IssueItemUiTest.kt
+++ b/android/feature/kotlin-weekly-issue/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/kotlinweeklyissue/component/IssueItemUiTest.kt
@@ -1,0 +1,33 @@
+package io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component
+
+import io.github.reactivecircus.kstreamlined.android.foundation.screenshottesting.tester.SnapshotTester
+import io.github.reactivecircus.kstreamlined.android.foundation.screenshottesting.tester.ThemeVariantInjector
+import io.github.reactivecircus.kstreamlined.kmp.model.feed.KotlinWeeklyIssueItem
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(ThemeVariantInjector::class)
+class IssueItemUiTest {
+
+    @get:Rule
+    val snapshotTester = SnapshotTester()
+
+    @Test
+    fun snapshot_IssueItemUi() {
+        snapshotTester.snapshot {
+            IssueItemUi(
+                item = KotlinWeeklyIssueItem(
+                    title = "Amper Update – December 2023",
+                    summary = "Last month JetBrains introduced Amper, a tool to improve the" +
+                        " project configuration user experience. Marton Braun gives us an update" +
+                        " about its state in December 2023.",
+                    url = "https://blog.jetbrains.com/amper/2023/12/amper-update-december-2023/",
+                    source = "blog.jetbrains.com",
+                    group = KotlinWeeklyIssueItem.Group.Announcements,
+                ),
+                onItemClick = {},
+            )
+        }
+    }
+}

--- a/android/feature/kotlin-weekly-issue/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/kotlinweeklyissue/component/KotlinWeeklyIssueScreenTest.kt
+++ b/android/feature/kotlin-weekly-issue/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/kotlinweeklyissue/component/KotlinWeeklyIssueScreenTest.kt
@@ -1,0 +1,100 @@
+package io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component
+
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.runtime.Composable
+import io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.KotlinWeeklyIssueScreen
+import io.github.reactivecircus.kstreamlined.android.foundation.screenshottesting.tester.SnapshotTester
+import io.github.reactivecircus.kstreamlined.android.foundation.screenshottesting.tester.ThemeVariantInjector
+import io.github.reactivecircus.kstreamlined.kmp.model.feed.KotlinWeeklyIssueItem
+import io.github.reactivecircus.kstreamlined.kmp.presentation.kotlinweeklyissue.KotlinWeeklyIssueUiState
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(ThemeVariantInjector::class)
+class KotlinWeeklyIssueScreenTest {
+
+    @get:Rule
+    val snapshotTester = SnapshotTester()
+
+    @Test
+    fun snapshot_KotlinWeeklyIssueScreen_InFlight() {
+        snapshotTester.snapshot {
+            KotlinWeeklyIssueScreenSnapshot(
+                uiState = KotlinWeeklyIssueUiState.InFlight,
+            )
+        }
+    }
+
+    @Test
+    fun snapshot_KotlinWeeklyIssueScreen_Content() {
+        snapshotTester.snapshot {
+            KotlinWeeklyIssueScreenSnapshot(
+                uiState = KotlinWeeklyIssueUiState.Content(
+                    id = "1",
+                    contentUrl = "content-url",
+                    issueItems = mapOf(
+                        KotlinWeeklyIssueItem.Group.Announcements to listOf(
+                            KotlinWeeklyIssueItem(
+                                title = "Apply for Google Summer of Code 2025 and Contribute to the Kotlin Ecosystem",
+                                summary = "The Kotlin Foundation is once again participating in Google Summer of Code. If you are thinking of participating, check out this announcement.",
+                                url = "url",
+                                source = "blog.jetbrains.com",
+                                group = KotlinWeeklyIssueItem.Group.Announcements
+                            )
+                        ),
+                        KotlinWeeklyIssueItem.Group.Articles to listOf(
+                            KotlinWeeklyIssueItem(
+                                title = "Strong skipping does not fix Kotlin collections in Jetpack Compose",
+                                summary = "Watch out when you are using List, Map, Set, etc in Compose. Jorge Castillo explains what strong skipping in Compose does not fix.",
+                                url = "url",
+                                source = "newsletter.jorgecastillo.dev",
+                                group = KotlinWeeklyIssueItem.Group.Articles
+                            )
+                        ),
+                        KotlinWeeklyIssueItem.Group.Videos to listOf(
+                            KotlinWeeklyIssueItem(
+                                title = "A full guide to MongoDB with Kotlin coroutines in Ktor",
+                                summary = "Piotr from Codersee explains in this video how to integrate a Ktor application with the MongoDB database and Kotlin coroutines.",
+                                url = "url",
+                                source = "www.youtube.com",
+                                group = KotlinWeeklyIssueItem.Group.Videos
+                            )
+                        ),
+                    ),
+                    savedForLater = true
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun snapshot_KotlinWeeklyIssueScreen_Error() {
+        snapshotTester.snapshot {
+            KotlinWeeklyIssueScreenSnapshot(
+                uiState = KotlinWeeklyIssueUiState.Error,
+            )
+        }
+    }
+
+    @OptIn(ExperimentalSharedTransitionApi::class)
+    @Composable
+    fun KotlinWeeklyIssueScreenSnapshot(
+        uiState: KotlinWeeklyIssueUiState,
+    ) {
+        SharedTransitionLayout {
+            KotlinWeeklyIssueScreen(
+                topBarBoundsKey = "",
+                titleElementKey = "",
+                id = "1",
+                title = "Issue #448",
+                onNavigateUp = {},
+                onShareButtonClick = {},
+                onOpenLink = {},
+                uiState = uiState,
+                eventSink = {},
+            )
+        }
+    }
+}

--- a/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_IssueGroupUiTest_snapshot_IssueGroupUi[Android,Dark].png
+++ b/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_IssueGroupUiTest_snapshot_IssueGroupUi[Android,Dark].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f14bb52dcbba864f7bbbeac07cac2f0c8a4a7bba344596765ca171a8c47abfa
+size 4180

--- a/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_IssueGroupUiTest_snapshot_IssueGroupUi[Android,Light].png
+++ b/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_IssueGroupUiTest_snapshot_IssueGroupUi[Android,Light].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b29395985a5bba0c4b97d6679c1ae58caadf18e738024074a7d5a45720de0c3
+size 4144

--- a/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_IssueGroupUiTest_snapshot_IssueGroupUi[Announcements,Dark].png
+++ b/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_IssueGroupUiTest_snapshot_IssueGroupUi[Announcements,Dark].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f63def4df86803142cff70b88dd33f089441ed54e36c2a98efcd8e29012976a
+size 6548

--- a/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_IssueGroupUiTest_snapshot_IssueGroupUi[Announcements,Light].png
+++ b/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_IssueGroupUiTest_snapshot_IssueGroupUi[Announcements,Light].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8df09218698ec14752c784985aa28f121473d1e310b65da747be5f95338843ef
+size 6515

--- a/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_IssueGroupUiTest_snapshot_IssueGroupUi[Articles,Dark].png
+++ b/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_IssueGroupUiTest_snapshot_IssueGroupUi[Articles,Dark].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de94f1347cf0b1a2027656281a551c39e406e013b6e7e5bd7422329e1ae45602
+size 4268

--- a/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_IssueGroupUiTest_snapshot_IssueGroupUi[Articles,Light].png
+++ b/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_IssueGroupUiTest_snapshot_IssueGroupUi[Articles,Light].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab8dd512784848c8f3b25430488806ab6079be183f6e8659fa93302a67e173dc
+size 4229

--- a/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_IssueGroupUiTest_snapshot_IssueGroupUi[Dark].png
+++ b/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_IssueGroupUiTest_snapshot_IssueGroupUi[Dark].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f63def4df86803142cff70b88dd33f089441ed54e36c2a98efcd8e29012976a
+size 6548

--- a/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_IssueGroupUiTest_snapshot_IssueGroupUi[Libraries,Dark].png
+++ b/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_IssueGroupUiTest_snapshot_IssueGroupUi[Libraries,Dark].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2bf3f5ca9071ed1d0ded7fbae3cbffa7efcb64853cb357edfb364b81b3f0a707
+size 4976

--- a/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_IssueGroupUiTest_snapshot_IssueGroupUi[Libraries,Light].png
+++ b/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_IssueGroupUiTest_snapshot_IssueGroupUi[Libraries,Light].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:639b98005910589b17a5f14d5d8172379622f4422647948cbf417a90c6c42fef
+size 4976

--- a/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_IssueGroupUiTest_snapshot_IssueGroupUi[Light].png
+++ b/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_IssueGroupUiTest_snapshot_IssueGroupUi[Light].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8df09218698ec14752c784985aa28f121473d1e310b65da747be5f95338843ef
+size 6515

--- a/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_IssueGroupUiTest_snapshot_IssueGroupUi[Videos,Dark].png
+++ b/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_IssueGroupUiTest_snapshot_IssueGroupUi[Videos,Dark].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2ba32b3c7a4978aee38850e4eab308d444023993aecaa5e931dc179e8b3d20e
+size 3981

--- a/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_IssueGroupUiTest_snapshot_IssueGroupUi[Videos,Light].png
+++ b/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_IssueGroupUiTest_snapshot_IssueGroupUi[Videos,Light].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a9d516bce869e8c6ee18dc61a6dca8ea8cc61c87e606dcaee8d06fb30d3ccd5
+size 3945

--- a/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_IssueItemUiTest_snapshot_IssueItemUi[Dark].png
+++ b/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_IssueItemUiTest_snapshot_IssueItemUi[Dark].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d79e8e48cd529e674582efeceb391e25dd1d20864d8167e40a8692d5093ed23
+size 76285

--- a/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_IssueItemUiTest_snapshot_IssueItemUi[Light].png
+++ b/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_IssueItemUiTest_snapshot_IssueItemUi[Light].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd7d895f39ab66000d48f5bf38fe4ad63019e3d4d026485ff8821a3be4ca6629
+size 73805

--- a/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_KotlinWeeklyIssueScreenTest_snapshot_KotlinWeeklyIssueScreen_Content[Dark].png
+++ b/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_KotlinWeeklyIssueScreenTest_snapshot_KotlinWeeklyIssueScreen_Content[Dark].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5119505c91c77cce651bb809face1d0b8bdbeeba60daa288d1a3b0e0c5c709b
+size 100622

--- a/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_KotlinWeeklyIssueScreenTest_snapshot_KotlinWeeklyIssueScreen_Content[Light].png
+++ b/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_KotlinWeeklyIssueScreenTest_snapshot_KotlinWeeklyIssueScreen_Content[Light].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f35c52a334d0b3a7362cd7f823ba7e82a7f792e7c21bfeeeaa3baf33e59deb7
+size 94428

--- a/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_KotlinWeeklyIssueScreenTest_snapshot_KotlinWeeklyIssueScreen_Error[Dark].png
+++ b/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_KotlinWeeklyIssueScreenTest_snapshot_KotlinWeeklyIssueScreen_Error[Dark].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c553374432ec8eec3cca42241e528bb84cc1b6ebe1765caab1790305059e614
+size 31603

--- a/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_KotlinWeeklyIssueScreenTest_snapshot_KotlinWeeklyIssueScreen_Error[Light].png
+++ b/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_KotlinWeeklyIssueScreenTest_snapshot_KotlinWeeklyIssueScreen_Error[Light].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5d02949619792fc8a2a1af4ea42644cdc28c929ca16719eae1dae39315582ae
+size 30551

--- a/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_KotlinWeeklyIssueScreenTest_snapshot_KotlinWeeklyIssueScreen_InFlight[Dark].png
+++ b/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_KotlinWeeklyIssueScreenTest_snapshot_KotlinWeeklyIssueScreen_InFlight[Dark].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55ac43069f3f3e403b3d9d5e53213211b47194a6d23619237619946efb9c47ea
+size 12398

--- a/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_KotlinWeeklyIssueScreenTest_snapshot_KotlinWeeklyIssueScreen_InFlight[Light].png
+++ b/android/feature/kotlin-weekly-issue/src/test/snapshots/images/io.github.reactivecircus.kstreamlined.android.feature.kotlinweeklyissue.component_KotlinWeeklyIssueScreenTest_snapshot_KotlinWeeklyIssueScreen_InFlight[Light].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d35c9f66577f211a03e69f4b6dce22149bed18109d3df2bc39b12d32679121bd
+size 11980

--- a/android/feature/saved-for-later/build.gradle.kts
+++ b/android/feature/saved-for-later/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
     implementation(project(":kmp:feed-datasource"))
     implementation(project(":kmp:presentation:saved-for-later"))
 
-    // Hilt
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
 }

--- a/android/feature/talking-kotlin-episode/build.gradle.kts
+++ b/android/feature/talking-kotlin-episode/build.gradle.kts
@@ -26,11 +26,8 @@ dependencies {
     implementation(project(":kmp:feed-datasource"))
     implementation(project(":kmp:presentation:talking-kotlin-episode"))
 
-    // AndroidX
     implementation(libs.androidx.media3.exoplayer)
     implementation(libs.androidx.tracing)
-
-    // Hilt
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
 

--- a/android/foundation/common-ui/feed/build.gradle.kts
+++ b/android/foundation/common-ui/feed/build.gradle.kts
@@ -12,11 +12,8 @@ dependencies {
     implementation(project(":foundation:compose-utils"))
     implementation(project(":kmp:model"))
 
-    // AndroidX
     implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.compose.ui.tooling)
     implementation(libs.androidx.tracing)
-
-    // Image loading
     implementation(libs.coil.compose)
 }

--- a/android/foundation/compose-utils/build.gradle.kts
+++ b/android/foundation/compose-utils/build.gradle.kts
@@ -8,6 +8,5 @@ android {
 }
 
 dependencies {
-    // AndroidX
     implementation(libs.androidx.compose.foundation)
 }

--- a/android/foundation/designsystem/build.gradle.kts
+++ b/android/foundation/designsystem/build.gradle.kts
@@ -12,7 +12,6 @@ android {
 }
 
 dependencies {
-    // AndroidX
     implementation(libs.androidx.compose.materialIcons)
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.foundation)

--- a/android/foundation/scheduled-work/build.gradle.kts
+++ b/android/foundation/scheduled-work/build.gradle.kts
@@ -10,13 +10,10 @@ android {
 dependencies {
     implementation(project(":kmp:feed-sync:common"))
 
-    // AndroidX
     implementation(libs.androidx.work.runtime)
     implementation(libs.androidx.hilt.work)
     ksp(libs.androidx.hilt.compiler)
     implementation(libs.androidx.tracing)
-
-    // Hilt
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
 }

--- a/android/foundation/screenshot-testing/paparazzi/build.gradle.kts
+++ b/android/foundation/screenshot-testing/paparazzi/build.gradle.kts
@@ -4,9 +4,6 @@ plugins {
 }
 
 dependencies {
-    // AndroidX
     implementation(libs.androidx.compose.runtime)
-
-    // Paparazzi
     implementation(libs.paparazzi)
 }

--- a/android/foundation/screenshot-testing/tester/build.gradle.kts
+++ b/android/foundation/screenshot-testing/tester/build.gradle.kts
@@ -11,9 +11,6 @@ dependencies {
     api(project(":foundation:screenshot-testing:paparazzi"))
     implementation(project(":foundation:designsystem"))
 
-    // AndroidX
     implementation(libs.androidx.compose.foundation)
-
-    // Paparazzi
     implementation(libs.paparazzi)
 }

--- a/android/foundation/screenshot-testing/tester/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/screenshottesting/tester/SnapshotTester.kt
+++ b/android/foundation/screenshot-testing/tester/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/screenshottesting/tester/SnapshotTester.kt
@@ -33,17 +33,18 @@ public class SnapshotTester(
         }
     }
 
-    private var themeVariant: ThemeVariantInjector.ThemeVariant? = null
+    private var currentThemeVariant: ThemeVariant? = null
 
-    internal fun setCurrentThemeVariant(themeVariant: ThemeVariantInjector.ThemeVariant) {
-        this.themeVariant = themeVariant
+    internal fun setCurrentThemeVariant(themeVariant: ThemeVariant) {
+        currentThemeVariant = themeVariant
     }
 
     public fun snapshot(
         addSurface: Boolean = true,
+        themeVariant: ThemeVariant? = null,
         content: @Composable () -> Unit,
     ) {
-        val darkTheme = themeVariant == ThemeVariantInjector.ThemeVariant.Dark
+        val darkTheme = themeVariant == ThemeVariant.Dark || currentThemeVariant == ThemeVariant.Dark
         runPaparazzi(testName = description.toTestName()) {
             CompositionLocalProvider(LocalInspectionMode provides true) {
                 KSTheme(darkTheme) {

--- a/android/foundation/screenshot-testing/tester/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/screenshottesting/tester/ThemeVariant.kt
+++ b/android/foundation/screenshot-testing/tester/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/screenshottesting/tester/ThemeVariant.kt
@@ -1,0 +1,6 @@
+package io.github.reactivecircus.kstreamlined.android.foundation.screenshottesting.tester
+
+public enum class ThemeVariant {
+    Light,
+    Dark,
+}

--- a/android/foundation/screenshot-testing/tester/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/screenshottesting/tester/ThemeVariantInjector.kt
+++ b/android/foundation/screenshot-testing/tester/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/screenshottesting/tester/ThemeVariantInjector.kt
@@ -80,11 +80,6 @@ public class ThemeVariantInjector(private val testClass: Class<*>) : Runner() {
         }
     }
 
-    internal enum class ThemeVariant {
-        Light,
-        Dark,
-    }
-
     private class ThemeVariantStatement(
         private val delegate: Statement,
         private val testInstance: Any,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ gradle-develocityPlugin = "3.19.1"
 gradle-toolchainsResolverPlugin = "0.9.0"
 appVersioning = "1.3.2"
 paparazzi = "1.3.5"
+testParameterInjector = "1.13"
 apollo = "4.1.1"
 apollo-adapters = "0.0.4"
 apollo-mockserver = "0.1.0"
@@ -136,6 +137,7 @@ sqldelight-androidDriver = { module = "app.cash.sqldelight:android-driver", vers
 sqldelight-nativeDriver = { module = "app.cash.sqldelight:native-driver", version.ref = "sqldelight" }
 sqldelight-sqliteDriver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
 paparazzi = { module = "app.cash.paparazzi:paparazzi", version.ref = "paparazzi" }
+testParameterInjector = { group = "com.google.testparameterinjector", name = "test-parameter-injector", version.ref = "testParameterInjector" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
 crashKios = { module = "co.touchlab:crashkios", version.ref = "crashKios" }


### PR DESCRIPTION
Update `SnapshotTester` to support using https://github.com/google/TestParameterInjector when more than theme variant need to be parameterized.

Add snapshots for `:feature:kotlin-weekly-issue`