### PR TITLE
Enable AGP built-in Kotlin with workarounds.

### DIFF
--- a/android/feature/talking-kotlin-episode/build.gradle.kts
+++ b/android/feature/talking-kotlin-episode/build.gradle.kts
@@ -29,5 +29,5 @@ dependencies {
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
 
-    testImplementation(kotlin("test"))
+    testImplementation(libs.kotlin.test.junit)
 }

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/AndroidApplicationConventionPlugin.kt
@@ -17,7 +17,6 @@ internal class AndroidApplicationConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
         with(pluginManager) {
             apply("com.android.application")
-            apply("org.jetbrains.kotlin.android")
         }
 
         extensions.configure<KotlinAndroidProjectExtension> {

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/AndroidLibraryConventionPlugin.kt
@@ -16,7 +16,6 @@ internal class AndroidLibraryConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
         with(pluginManager) {
             apply("com.android.library")
-            apply("org.jetbrains.kotlin.android")
         }
 
         extensions.configure<KotlinAndroidProjectExtension> {

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/AndroidTestConventionPlugin.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/AndroidTestConventionPlugin.kt
@@ -13,7 +13,6 @@ internal class AndroidTestConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
         with(pluginManager) {
             apply("com.android.test")
-            apply("org.jetbrains.kotlin.android")
         }
 
         extensions.configure<KotlinAndroidProjectExtension> {

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/buildlogic/kotlinBuildLogic.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/buildlogic/kotlinBuildLogic.kt
@@ -20,6 +20,16 @@ internal fun KotlinProjectExtension.configureKotlin(
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_11)
             jvmDefault.set(JvmDefaultMode.NO_COMPATIBILITY)
+            // TODO investigate:
+            //  why `-Xskip-prerelease-check` is needed when compiling Android library projects with experimental language features enabled (see https://youtrack.jetbrains.com/issue/KT-75588)
+            //  why opt-in from languageSettings DSL no longer works for Android library projects
+            freeCompilerArgs.addAll(
+                "-Xskip-prerelease-check"
+            )
+            optIn.addAll(
+                "kotlin.time.ExperimentalTime",
+                "kotlin.experimental.ExperimentalObjCName",
+            )
         }
     }
     target.tasks.withType<JavaCompile>().configureEach {

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,10 +35,6 @@ android.useConditionalKeepRules=true
 android.keepWorkerActionServicesBetweenBuilds=true
 android.enablePartialRIncrementalBuilds=true
 
-# TODO investigate following built-in Kotlin issues:
-#  compiler version mismatch when consuming KMP code from Android library module
-#  languageSettings in kotlinBuildLogic no longer works
-android.builtInKotlin=false
 # TODO remove once Hilt supports the new DSL https://github.com/google/dagger/issues/4944
 android.newDsl=false
 # TODO remove once https://issuetracker.google.com/issues/443185855 / https://github.com/firebase/firebase-android-sdk/issues/7367 is fixed

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -138,6 +138,8 @@ sqldelight-androidDriver = { module = "app.cash.sqldelight:android-driver", vers
 sqldelight-nativeDriver = { module = "app.cash.sqldelight:native-driver", version.ref = "sqldelight" }
 sqldelight-sqliteDriver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
 ksoup = { module = "com.fleeksoft.ksoup:ksoup", version.ref = "ksoup" }
+# TODO: why kotlin("test") no longer works in Android library projects?
+kotlin-test-junit = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit", version.ref = "kotlin" }
 paparazzi = { module = "app.cash.paparazzi:paparazzi", version.ref = "paparazzi" }
 testParameterInjector = { group = "com.google.testparameterinjector", name = "test-parameter-injector", version.ref = "testParameterInjector" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }


### PR DESCRIPTION
Enable built-in Kotlin in AGP 9.