### PR TITLE
Update Firebase. Update tracking issue for `android.r8.strictFullModeForKeepRules`.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -41,7 +41,7 @@ android.enablePartialRIncrementalBuilds=true
 android.builtInKotlin=false
 # TODO remove once Hilt supports the new DSL https://github.com/google/dagger/issues/4944
 android.newDsl=false
-# TODO remove once https://issuetracker.google.com/issues/443185855 / https://github.com/firebase/firebase-android-sdk/issues/7367 is fixed
+# TODO remove once https://issuetracker.google.com/issues/445108426 is fixed
 android.r8.strictFullModeForKeepRules=false
 
 xcodeproj=./ios

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,12 +20,12 @@ hilt = "2.57.1"
 kotlinx-coroutines = "1.10.2"
 kotlinx-datetime = "0.7.1"
 kotlinx-serialization = "1.9.0"
-firebase-analytics = "22.5.0"
+firebase-analytics = "23.0.0"
 firebase-appDistributionPlugin = "5.1.1"
-firebase-remoteConfig = "22.1.2"
-firebase-perf = "21.0.5"
+firebase-remoteConfig = "23.0.0"
+firebase-perf = "22.0.1"
 firebase-perfPlugin = "2.0.1"
-firebase-crashlytics = "19.4.4"
+firebase-crashlytics = "20.0.1"
 firebase-crashlyticsPlugin = "3.0.6"
 androidx-lint = "1.0.0-alpha05"
 androidx-compose-ui = "1.10.0-alpha03"
@@ -92,10 +92,10 @@ kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-c
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
-firebase-analytics = { module = "com.google.firebase:firebase-analytics-ktx", version.ref = "firebase-analytics" }
-firebase-remoteConfig = { module = "com.google.firebase:firebase-config-ktx", version.ref = "firebase-remoteConfig" }
-firebase-perf = { module = "com.google.firebase:firebase-perf-ktx", version.ref = "firebase-perf" }
-firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics-ktx", version.ref = "firebase-crashlytics" }
+firebase-analytics = { module = "com.google.firebase:firebase-analytics", version.ref = "firebase-analytics" }
+firebase-remoteConfig = { module = "com.google.firebase:firebase-config", version.ref = "firebase-remoteConfig" }
+firebase-perf = { module = "com.google.firebase:firebase-perf", version.ref = "firebase-perf" }
+firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics", version.ref = "firebase-crashlytics" }
 androidx-lintGradle = { group = "androidx.lint", name = "lint-gradle", version.ref = "androidx-lint" }
 androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "androidx-compose-ui" }
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "androidx-compose-foundation" }


### PR DESCRIPTION
https://github.com/firebase/firebase-android-sdk/issues/7367 is resolved in latest version of crashlytics.

`android.r8.strictFullModeForKeepRules` still can't be enabled due to a work manager crash: https://issuetracker.google.com/issues/445108426