### PR TITLE
Remove `kotlin-dsl` from `build-logic`.

### DIFF
--- a/build-logic/kstreamlined-gradle-plugin/build.gradle.kts
+++ b/build-logic/kstreamlined-gradle-plugin/build.gradle.kts
@@ -4,7 +4,8 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    `kotlin-dsl`
+    `java-gradle-plugin`
+    alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.lint)
     alias(libs.plugins.detekt)
 }
@@ -85,7 +86,7 @@ detekt {
     parallel = true
 }
 
-tasks.withType<Detekt>().configureEach {
+tasks.withType(Detekt::class.java).configureEach {
     jvmTarget = JvmTarget.JVM_22.target
     reports {
         xml.required.set(false)

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/AndroidApplicationConventionPlugin.kt
@@ -10,7 +10,6 @@ import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureKotlin
 import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureTest
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.configure
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 
 internal class AndroidApplicationConventionPlugin : Plugin<Project> {
@@ -20,17 +19,17 @@ internal class AndroidApplicationConventionPlugin : Plugin<Project> {
             apply("org.jetbrains.kotlin.android")
         }
 
-        extensions.configure<KotlinAndroidProjectExtension> {
-            configureKotlin(target, enableExplicitApi = false)
+        extensions.configure(KotlinAndroidProjectExtension::class.java) {
+            it.configureKotlin(target, enableExplicitApi = false)
         }
 
-        extensions.configure<ApplicationExtension> {
-            configureCommonAndroidExtension(target)
-            configureAndroidApplicationExtension()
+        extensions.configure(ApplicationExtension::class.java) {
+            it.configureCommonAndroidExtension(target)
+            it.configureAndroidApplicationExtension()
         }
 
-        extensions.configure<ApplicationAndroidComponentsExtension> {
-            configureAndroidApplicationVariants()
+        extensions.configure(ApplicationAndroidComponentsExtension::class.java) {
+            it.configureAndroidApplicationVariants()
         }
 
         configureTest()

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/AndroidLibraryConventionPlugin.kt
@@ -9,7 +9,6 @@ import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureKotlin
 import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureTest
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.configure
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 
 internal class AndroidLibraryConventionPlugin : Plugin<Project> {
@@ -19,16 +18,16 @@ internal class AndroidLibraryConventionPlugin : Plugin<Project> {
             apply("org.jetbrains.kotlin.android")
         }
 
-        extensions.configure<KotlinAndroidProjectExtension> {
-            configureKotlin(target)
+        extensions.configure(KotlinAndroidProjectExtension::class.java) {
+            it.configureKotlin(target)
         }
 
-        extensions.configure<LibraryExtension> {
-            configureCommonAndroidExtension(target)
+        extensions.configure(LibraryExtension::class.java) {
+            it.configureCommonAndroidExtension(target)
         }
 
-        extensions.configure<LibraryAndroidComponentsExtension> {
-            configureAndroidLibraryVariants()
+        extensions.configure(LibraryAndroidComponentsExtension::class.java) {
+            it.configureAndroidLibraryVariants()
         }
 
         configureTest()

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/AndroidScreenshotTestConventionPlugin.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/AndroidScreenshotTestConventionPlugin.kt
@@ -9,8 +9,6 @@ import isIdeBuild
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.testing.Test
-import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.withType
 import runningCheck
 import runningPaparazzi
 
@@ -18,24 +16,24 @@ internal class AndroidScreenshotTestConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
         pluginManager.apply("app.cash.paparazzi")
         pluginManager.withPlugin("app.cash.paparazzi") {
-            tasks.withType<Test>().configureEach {
+            tasks.withType(Test::class.java).configureEach { test ->
                 if (!runningCheck) {
                     // skip running regular unit tests when running one of the paparazzi tasks
                     // skip running paparazzi tests when running regular unit tests
-                    filter {
+                    test.filter {
                         if (runningPaparazzi) {
-                            includePatterns += "*.snapshot*"
+                            it.includePatterns += "*.snapshot*"
                         } else {
-                            excludePatterns += "*.snapshot*"
+                            it.excludePatterns += "*.snapshot*"
                         }
                     }
                 }
             }
-            tasks.withType<PrepareResourcesTask>().configureEach {
-                enabled = runningCheck || runningPaparazzi
+            tasks.withType(PrepareResourcesTask::class.java).configureEach {
+                it.enabled = runningCheck || runningPaparazzi
             }
             tasks.named("check").configure {
-                dependsOn("verifyPaparazzi")
+                it.dependsOn("verifyPaparazzi")
             }
         }
 
@@ -43,19 +41,19 @@ internal class AndroidScreenshotTestConventionPlugin : Plugin<Project> {
 
         if (runningCheck || runningPaparazzi || isIdeBuild) {
             pluginManager.withPlugin("com.android.library") {
-                extensions.configure<LibraryAndroidComponentsExtension> {
-                    beforeVariants {
-                        (it as HasUnitTestBuilder).enableUnitTest = true
+                extensions.configure(LibraryAndroidComponentsExtension::class.java) {
+                    it.beforeVariants { variantBuilder ->
+                        (variantBuilder as HasUnitTestBuilder).enableUnitTest = true
                     }
                 }
-                extensions.configure<LibraryExtension> {
-                    androidResources.enable = true
+                extensions.configure(LibraryExtension::class.java) {
+                    it.androidResources.enable = true
                 }
             }
             pluginManager.withPlugin("com.android.application") {
-                extensions.configure<ApplicationAndroidComponentsExtension> {
-                    beforeVariants {
-                        (it as HasUnitTestBuilder).enableUnitTest = true
+                extensions.configure(ApplicationAndroidComponentsExtension::class.java) {
+                    it.beforeVariants { variantBuilder ->
+                        (variantBuilder as HasUnitTestBuilder).enableUnitTest = true
                     }
                 }
             }

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/AndroidTestConventionPlugin.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/AndroidTestConventionPlugin.kt
@@ -6,7 +6,6 @@ import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureDetekt
 import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureKotlin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.configure
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 
 internal class AndroidTestConventionPlugin : Plugin<Project> {
@@ -16,12 +15,12 @@ internal class AndroidTestConventionPlugin : Plugin<Project> {
             apply("org.jetbrains.kotlin.android")
         }
 
-        extensions.configure<KotlinAndroidProjectExtension> {
-            configureKotlin(target, enableExplicitApi = false)
+        extensions.configure(KotlinAndroidProjectExtension::class.java) {
+            it.configureKotlin(target, enableExplicitApi = false)
         }
 
-        extensions.configure<TestExtension> {
-            configureAndroidTestExtension()
+        extensions.configure(TestExtension::class.java) {
+            it.configureAndroidTestExtension()
         }
 
         configureDetekt()

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/ComposeConventionPlugin.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/ComposeConventionPlugin.kt
@@ -2,25 +2,24 @@ package io.github.reactivecircus.kstreamlined.gradle
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.configure
 import org.jetbrains.kotlin.compose.compiler.gradle.ComposeCompilerGradlePluginExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 
 internal class ComposeConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
         pluginManager.apply("org.jetbrains.kotlin.plugin.compose")
-        configure<ComposeCompilerGradlePluginExtension> {
+        extensions.configure(ComposeCompilerGradlePluginExtension::class.java) {
             val stabilityConfigFile = layout.projectDirectory.file("compose_stability_config.conf")
             if (stabilityConfigFile.asFile.exists()) {
-                stabilityConfigurationFiles.add(stabilityConfigFile)
+                it.stabilityConfigurationFiles.add(stabilityConfigFile)
             }
             if (providers.gradleProperty("enableComposeCompilerReports").orNull == "true") {
-                metricsDestination.set(layout.buildDirectory.dir("compose_metrics"))
-                reportsDestination.set(layout.buildDirectory.dir("compose_metrics"))
+                it.metricsDestination.set(layout.buildDirectory.dir("compose_metrics"))
+                it.reportsDestination.set(layout.buildDirectory.dir("compose_metrics"))
             }
-            targetKotlinPlatforms.set(
-                KotlinPlatformType.values().filterNot {
-                    it == KotlinPlatformType.js || it == KotlinPlatformType.wasm
+            it.targetKotlinPlatforms.set(
+                KotlinPlatformType.entries.filterNot { target ->
+                    target == KotlinPlatformType.js || target == KotlinPlatformType.wasm
                 }
             )
         }

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/KmpAndroidAndIosConventionPlugin.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/KmpAndroidAndIosConventionPlugin.kt
@@ -7,7 +7,6 @@ import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureKotlin
 import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureTest
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.configure
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 internal class KmpAndroidAndIosConventionPlugin : Plugin<Project> {
@@ -18,9 +17,9 @@ internal class KmpAndroidAndIosConventionPlugin : Plugin<Project> {
             apply("com.android.lint")
         }
 
-        extensions.configure<KotlinMultiplatformExtension> {
-            configureKmpTargets(target, KmpModuleType.AndroidAndIos)
-            configureKotlin(target)
+        extensions.configure(KotlinMultiplatformExtension::class.java) {
+            it.configureKmpTargets(target, KmpModuleType.AndroidAndIos)
+            it.configureKotlin(target)
         }
 
         configureTest()

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/KmpIosOnlyConventionPlugin.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/KmpIosOnlyConventionPlugin.kt
@@ -7,16 +7,15 @@ import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureKotlin
 import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureTest
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.configure
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 internal class KmpIosOnlyConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
         pluginManager.apply("org.jetbrains.kotlin.multiplatform")
 
-        extensions.configure<KotlinMultiplatformExtension> {
-            configureKmpTargets(target, KmpModuleType.IosOnly)
-            configureKotlin(target)
+        extensions.configure(KotlinMultiplatformExtension::class.java) {
+            it.configureKmpTargets(target, KmpModuleType.IosOnly)
+            it.configureKotlin(target)
         }
 
         configureTest()

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/KmpJvmAndIosConventionPlugin.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/KmpJvmAndIosConventionPlugin.kt
@@ -7,7 +7,6 @@ import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureKotlin
 import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureTest
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.configure
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 internal class KmpJvmAndIosConventionPlugin : Plugin<Project> {
@@ -17,9 +16,9 @@ internal class KmpJvmAndIosConventionPlugin : Plugin<Project> {
             apply("com.android.lint")
         }
 
-        extensions.configure<KotlinMultiplatformExtension> {
-            configureKmpTargets(target, KmpModuleType.JvmAndIos)
-            configureKotlin(target)
+        extensions.configure(KotlinMultiplatformExtension::class.java) {
+            it.configureKmpTargets(target, KmpModuleType.JvmAndIos)
+            it.configureKotlin(target)
         }
 
         configureTest()

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/KmpTestConventionPlugin.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/KmpTestConventionPlugin.kt
@@ -3,26 +3,25 @@ package io.github.reactivecircus.kstreamlined.gradle
 import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureKmpTest
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.configure
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.powerassert.gradle.PowerAssertGradleExtension
 
 internal class KmpTestConventionPlugin : Plugin<Project> {
 
-    override fun apply(target: Project) = with(target) {
+    override fun apply(target: Project): Unit = with(target) {
         with(pluginManager) {
             apply("org.jetbrains.kotlin.multiplatform")
             apply("org.jetbrains.kotlin.plugin.power-assert")
         }
 
-        extensions.configure<KotlinMultiplatformExtension> {
-            configureKmpTest()
+        extensions.configure(KotlinMultiplatformExtension::class.java) {
+            it.configureKmpTest()
         }
 
         @OptIn(ExperimentalKotlinGradlePluginApi::class)
-        extensions.configure<PowerAssertGradleExtension> {
-            functions.set(
+        extensions.configure(PowerAssertGradleExtension::class.java) {
+            it.functions.set(
                 listOf(
                     "kotlin.assert",
                     "kotlin.test.assertEquals",

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/KotlinJvmConventionPlugin.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/KotlinJvmConventionPlugin.kt
@@ -5,7 +5,6 @@ import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureKotlin
 import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureTest
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.configure
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 
 internal class KotlinJvmConventionPlugin : Plugin<Project> {
@@ -15,8 +14,8 @@ internal class KotlinJvmConventionPlugin : Plugin<Project> {
             apply("com.android.lint")
         }
 
-        extensions.configure<KotlinJvmProjectExtension> {
-            configureKotlin(target)
+        extensions.configure(KotlinJvmProjectExtension::class.java) {
+            it.configureKotlin(target)
         }
 
         configureTest()

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/KspConventionPlugin.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/KspConventionPlugin.kt
@@ -3,17 +3,16 @@ package io.github.reactivecircus.kstreamlined.gradle
 import com.google.devtools.ksp.gradle.KspExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.configure
 
 internal class KspConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
         pluginManager.apply("com.google.devtools.ksp")
 
-        extensions.configure<KspExtension> {
+        extensions.configure(KspExtension::class.java) {
             if (hasHiltCompilerDependency) {
-                arg("dagger.fastInit", "enabled")
-                arg("dagger.strictMultibindingValidation", "enabled")
-                arg("dagger.experimentalDaggerErrorMessages", "enabled")
+                it.arg("dagger.fastInit", "enabled")
+                it.arg("dagger.strictMultibindingValidation", "enabled")
+                it.arg("dagger.experimentalDaggerErrorMessages", "enabled")
             }
         }
 
@@ -21,7 +20,7 @@ internal class KspConventionPlugin : Plugin<Project> {
         tasks.named {
             it.startsWith("ksp") && it.endsWith("UnitTestKotlin")
         }.configureEach {
-            enabled = false
+            it.enabled = false
         }
     }
 }

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/RootPlugin.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/RootPlugin.kt
@@ -3,7 +3,6 @@ package io.github.reactivecircus.kstreamlined.gradle
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.Delete
-import org.gradle.kotlin.dsl.register
 
 internal class RootPlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -11,9 +10,9 @@ internal class RootPlugin : Plugin<Project> {
         // target.pluginManager.apply("com.squareup.invert")
 
         // register task for cleaning the build directory in the root project
-        target.tasks.register<Delete>("clean") {
+        target.tasks.register("clean", Delete::class.java) {
             @Suppress("UnstableApiUsage")
-            delete(target.isolated.rootProject.projectDirectory.file("build"))
+            it.delete(target.isolated.rootProject.projectDirectory.file("build"))
         }
     }
 }

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/buildlogic/detektBuildLogic.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/buildlogic/detektBuildLogic.kt
@@ -3,11 +3,7 @@ package io.github.reactivecircus.kstreamlined.gradle.buildlogic
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektPlugin
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
-import org.gradle.accessors.dm.LibrariesForLibs
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.the
-import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 /**
@@ -18,23 +14,23 @@ internal fun Project.configureDetekt() {
     pluginManager.apply(DetektPlugin::class.java)
 
     // enable Ktlint formatting
-    dependencies.add("detektPlugins", the<LibrariesForLibs>().plugin.detektFormatting)
+    dependencies.add("detektPlugins", libs.plugin.detektFormatting)
 
-    plugins.withType<DetektPlugin>().configureEach {
-        extensions.configure<DetektExtension> {
-            source.from(files("src/"))
-            config.from(files("${project.rootDir}/detekt.yml"))
-            buildUponDefaultConfig = true
-            allRules = true
-            parallel = true
+    plugins.withType(DetektPlugin::class.java).configureEach {
+        extensions.configure(DetektExtension::class.java) {
+            it.source.from(files("src/"))
+            it.config.from(files("${project.rootDir}/detekt.yml"))
+            it.buildUponDefaultConfig = true
+            it.allRules = true
+            it.parallel = true
         }
-        tasks.withType<Detekt>().configureEach {
-            jvmTarget = JvmTarget.JVM_17.target
-            reports {
-                xml.required.set(false)
-                txt.required.set(false)
-                sarif.required.set(false)
-                md.required.set(false)
+        tasks.withType(Detekt::class.java).configureEach {
+            it.jvmTarget = JvmTarget.JVM_17.target
+            it.reports { report ->
+                report.xml.required.set(false)
+                report.txt.required.set(false)
+                report.sarif.required.set(false)
+                report.md.required.set(false)
             }
         }
     }

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/buildlogic/kmpBuildLogic.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/buildlogic/kmpBuildLogic.kt
@@ -3,7 +3,6 @@ package io.github.reactivecircus.kstreamlined.gradle.buildlogic
 import com.android.build.api.dsl.androidLibrary
 import isAppleSilicon
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.NativeOutputKind
@@ -68,10 +67,10 @@ internal fun KotlinMultiplatformExtension.configureKmpTest() {
             }
         }
     }
-    targets.withType<KotlinNativeTarget>().configureEach {
-        binaries.configureEach {
-            if (outputKind == NativeOutputKind.TEST) {
-                linkerOpts("-lsqlite3")
+    targets.withType(KotlinNativeTarget::class.java).configureEach {
+        it.binaries.configureEach {
+            if (it.outputKind == NativeOutputKind.TEST) {
+                it.linkerOpts("-lsqlite3")
             }
         }
     }

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/buildlogic/kotlinBuildLogic.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/buildlogic/kotlinBuildLogic.kt
@@ -3,7 +3,6 @@ package io.github.reactivecircus.kstreamlined.gradle.buildlogic
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.tasks.compile.JavaCompile
-import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
@@ -16,18 +15,18 @@ internal fun KotlinProjectExtension.configureKotlin(
     target: Project,
     enableExplicitApi: Boolean = true,
 ) {
-    target.tasks.withType<KotlinCompile>().configureEach {
-        compilerOptions {
+    target.tasks.withType(KotlinCompile::class.java).configureEach {
+        it.compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)
             jvmDefault.set(JvmDefaultMode.NO_COMPATIBILITY)
         }
     }
-    target.tasks.withType<JavaCompile>().configureEach {
-        sourceCompatibility = JavaVersion.VERSION_17.toString()
-        targetCompatibility = JavaVersion.VERSION_17.toString()
+    target.tasks.withType(JavaCompile::class.java).configureEach {
+        it.sourceCompatibility = JavaVersion.VERSION_17.toString()
+        it.targetCompatibility = JavaVersion.VERSION_17.toString()
     }
     sourceSets.configureEach {
-        languageSettings {
+        it.languageSettings {
             progressiveMode = true
             optIn("kotlin.time.ExperimentalTime")
             optIn("kotlin.experimental.ExperimentalObjCName")

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/buildlogic/unitTestBuildLogic.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/buildlogic/unitTestBuildLogic.kt
@@ -3,15 +3,14 @@ package io.github.reactivecircus.kstreamlined.gradle.buildlogic
 import org.gradle.api.Project
 import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.logging.TestLogEvent
-import org.gradle.kotlin.dsl.withType
 
 /**
  * Configure JUnit test options if applicable.
  */
 internal fun Project.configureTest() {
-    tasks.withType<Test>().configureEach {
-        testLogging {
-            events(TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)
+    tasks.withType(Test::class.java).configureEach { test ->
+        test.testLogging {
+            it.events(TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)
         }
     }
 }

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/buildlogic/versionCatalogUtils.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/buildlogic/versionCatalogUtils.kt
@@ -1,0 +1,6 @@
+package io.github.reactivecircus.kstreamlined.gradle.buildlogic
+
+import org.gradle.accessors.dm.LibrariesForLibs
+import org.gradle.api.Project
+
+internal val Project.libs get() = extensions.getByName("libs") as LibrariesForLibs

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -146,5 +146,6 @@ kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
 crashKios = { module = "co.touchlab:crashkios", version.ref = "crashKios" }
 
 [plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 lint = { id = "com.android.lint", version.ref = "androidGradlePlugin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }


### PR DESCRIPTION
See https://mbonnin.net/2025-07-10_the_case_against_kotlin_dsl/.

Also `kotlin-dsl` currently doesn't work with [detekt 2.0.0-alpha.0](https://github.com/detekt/detekt/releases/tag/v2.0.0-alpha.0).