### PR TITLE
Detekt 2.0.0-alpha.0

### DIFF
--- a/android/app/src/debug/kotlin/io/github/reactivecircus/kstreamlined/android/DebugKSApp.kt
+++ b/android/app/src/debug/kotlin/io/github/reactivecircus/kstreamlined/android/DebugKSApp.kt
@@ -3,7 +3,6 @@ package io.github.reactivecircus.kstreamlined.android
 import leakcanary.AppWatcher
 
 class DebugKSApp : KSApp() {
-
     override fun onCreate() {
         super.onCreate()
 

--- a/android/app/src/demo/kotlin/io/github/reactivecircus/kstreamlined/android/di/EdgeRemoteModule.kt
+++ b/android/app/src/demo/kotlin/io/github/reactivecircus/kstreamlined/android/di/EdgeRemoteModule.kt
@@ -11,7 +11,6 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object EdgeRemoteModule {
-
     @Provides
     @Singleton
     fun feedService(): FeedService {

--- a/android/app/src/devAndProd/kotlin/io/github/reactivecircus/kstreamlined/android/di/CloudRemoteModule.kt
+++ b/android/app/src/devAndProd/kotlin/io/github/reactivecircus/kstreamlined/android/di/CloudRemoteModule.kt
@@ -20,7 +20,6 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object CloudRemoteModule {
-
     @Provides
     @Singleton
     fun feedService(apolloClient: ApolloClient): FeedService {
@@ -39,7 +38,7 @@ object CloudRemoteModule {
                 ApolloClientAwarenessInterceptor(
                     clientName = "KStreamlined Android",
                     clientVersion = BuildConfig.VERSION_NAME,
-                )
+                ),
             )
             .store(ApolloClientConfigs.apolloStore, writeToCacheAsynchronously = true)
             .build()

--- a/android/app/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/KSActivity.kt
+++ b/android/app/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/KSActivity.kt
@@ -40,7 +40,6 @@ import kotlinx.parcelize.Parcelize
 @OptIn(ExperimentalSharedTransitionApi::class)
 @AndroidEntryPoint
 class KSActivity : ComponentActivity() {
-
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
 
@@ -54,7 +53,7 @@ class KSActivity : ComponentActivity() {
 
                 var navDestination: NavDestination by rememberSaveable {
                     mutableStateOf(
-                        NavDestination.Main
+                        NavDestination.Main,
                     )
                 }
 
@@ -169,7 +168,6 @@ class KSActivity : ComponentActivity() {
 }
 
 private sealed interface NavDestination : Parcelable {
-
     @Parcelize
     data object Main : NavDestination
 
@@ -227,11 +225,12 @@ private fun ComponentActivity.NavigationBarStyleEffect() {
 private enum class SystemNavigationMode {
     ThreeButton,
     TwoButton,
-    Gesture;
+    Gesture,
+    ;
 
     companion object {
         fun of(context: Context) = entries.getOrNull(
-            Settings.Secure.getInt(context.contentResolver, "navigation_mode", -1)
+            Settings.Secure.getInt(context.contentResolver, "navigation_mode", -1),
         )
     }
 }

--- a/android/app/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/KSApp.kt
+++ b/android/app/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/KSApp.kt
@@ -14,7 +14,6 @@ import javax.inject.Inject
 
 @HiltAndroidApp
 open class KSApp : Application(), SingletonImageLoader.Factory, Configuration.Provider {
-
     @Inject
     lateinit var imageLoader: Lazy<ImageLoader>
 

--- a/android/app/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/MainScreen.kt
+++ b/android/app/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/MainScreen.kt
@@ -67,7 +67,7 @@ fun SharedTransitionScope.MainScreen(
                         animatedVisibilityScope = animatedVisibilityScope,
                         listState = homeListState,
                         onViewItem = { item -> onViewItem(item, NavItemKey.Home) },
-                        modifier = Modifier.pagerScaleTransition(it, pagerState)
+                        modifier = Modifier.pagerScaleTransition(it, pagerState),
                     )
                 }
 
@@ -76,7 +76,7 @@ fun SharedTransitionScope.MainScreen(
                         animatedVisibilityScope = animatedVisibilityScope,
                         listState = savedListState,
                         onViewItem = { item -> onViewItem(item, NavItemKey.Saved) },
-                        modifier = Modifier.pagerScaleTransition(it, pagerState)
+                        modifier = Modifier.pagerScaleTransition(it, pagerState),
                     )
                 }
             }
@@ -101,11 +101,11 @@ fun SharedTransitionScope.MainScreen(
                     .padding(8.dp)
                     .align(Alignment.BottomCenter)
                     .renderInSharedTransitionScopeOverlay(
-                        zIndexInOverlay = 1f
+                        zIndexInOverlay = 1f,
                     )
                     .animateEnterExit(
                         enter = fadeIn() + slideInVertically(
-                            tween(delayMillis = 200, easing = LinearOutSlowInEasing)
+                            tween(delayMillis = 200, easing = LinearOutSlowInEasing),
                         ) { it * 2 },
                         exit = fadeOut(),
                     ),

--- a/android/app/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/di/AppModule.kt
+++ b/android/app/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/di/AppModule.kt
@@ -28,7 +28,6 @@ import kotlin.time.toJavaDuration
 @Module
 @InstallIn(SingletonComponent::class)
 object AppModule {
-
     @Provides
     @Singleton
     fun imageLoader(

--- a/android/app/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/di/DataModule.kt
+++ b/android/app/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/di/DataModule.kt
@@ -19,7 +19,6 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object DataModule {
-
     @Provides
     @Singleton
     fun feedDataSource(

--- a/android/app/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/di/PersistenceModule.kt
+++ b/android/app/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/di/PersistenceModule.kt
@@ -17,11 +17,10 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object PersistenceModule {
-
     @Provides
     @Singleton
     fun database(
-        @ApplicationContext context: Context
+        @ApplicationContext context: Context,
     ): KStreamlinedDatabase {
         return KStreamlinedDatabase(
             AndroidSqliteDriver(
@@ -36,7 +35,7 @@ object PersistenceModule {
             lastSyncMetadataAdapter = LastSyncMetadata.Adapter(
                 resource_typeAdapter = EnumColumnAdapter(),
                 last_sync_timeAdapter = InstantAdapter,
-            )
+            ),
         )
     }
 }

--- a/android/app/src/mock/kotlin/io/github/reactivecircus/kstreamlined/android/di/MockRemoteModule.kt
+++ b/android/app/src/mock/kotlin/io/github/reactivecircus/kstreamlined/android/di/MockRemoteModule.kt
@@ -11,7 +11,6 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object MockRemoteModule {
-
     @Provides
     @Singleton
     fun feedService(): FeedService {

--- a/android/benchmark/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/benchmark/baselineprofile/BaselineProfileGenerator.kt
+++ b/android/benchmark/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/benchmark/baselineprofile/BaselineProfileGenerator.kt
@@ -13,7 +13,6 @@ import org.junit.runner.RunWith
 @LargeTest
 @RunWith(AndroidJUnit4::class)
 class BaselineProfileGenerator {
-
     @get:Rule
     val rule = BaselineProfileRule()
 

--- a/android/benchmark/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/benchmark/home/HomeFeedRecompositionBenchmark.kt
+++ b/android/benchmark/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/benchmark/home/HomeFeedRecompositionBenchmark.kt
@@ -17,7 +17,6 @@ import org.junit.runner.RunWith
 @LargeTest
 @RunWith(AndroidJUnit4::class)
 class HomeFeedRecompositionBenchmark {
-
     @get:Rule
     val rule = MacrobenchmarkRule()
 
@@ -44,6 +43,6 @@ class HomeFeedRecompositionBenchmark {
             repeat(4) {
                 clickSaveButtonOnCard()
             }
-        }
+        },
     )
 }

--- a/android/benchmark/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/benchmark/home/HomeFeedScrollingBenchmark.kt
+++ b/android/benchmark/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/benchmark/home/HomeFeedScrollingBenchmark.kt
@@ -17,7 +17,6 @@ import org.junit.runner.RunWith
 @LargeTest
 @RunWith(AndroidJUnit4::class)
 class HomeFeedScrollingBenchmark {
-
     @get:Rule
     val rule = MacrobenchmarkRule()
 
@@ -46,6 +45,6 @@ class HomeFeedScrollingBenchmark {
         },
         measureBlock = {
             homeFeedListFlingDownUp()
-        }
+        },
     )
 }

--- a/android/benchmark/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/benchmark/home/homeActions.kt
+++ b/android/benchmark/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/benchmark/home/homeActions.kt
@@ -57,7 +57,8 @@ enum class CardType {
     KotlinBlog,
     KotlinYouTube,
     TalkingKotlin,
-    KotlinWeekly;
+    KotlinWeekly,
+    ;
 
     val resourceName: String
         get() = "${name.replaceFirstChar { it.lowercase(Locale.getDefault()) }}Card"

--- a/android/benchmark/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/benchmark/screentransition/ScreenTransitionBenchmark.kt
+++ b/android/benchmark/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/benchmark/screentransition/ScreenTransitionBenchmark.kt
@@ -21,7 +21,6 @@ import org.junit.runner.RunWith
 @LargeTest
 @RunWith(AndroidJUnit4::class)
 class ScreenTransitionBenchmark {
-
     @get:Rule
     val rule = MacrobenchmarkRule()
 
@@ -59,6 +58,6 @@ class ScreenTransitionBenchmark {
             clickCard(cardType)
             device.pressBack()
             pressHome()
-        }
+        },
     )
 }

--- a/android/benchmark/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/benchmark/startup/StartupBenchmark.kt
+++ b/android/benchmark/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/benchmark/startup/StartupBenchmark.kt
@@ -20,7 +20,6 @@ import org.junit.runner.RunWith
 @LargeTest
 @RunWith(AndroidJUnit4::class)
 class StartupBenchmark {
-
     @get:Rule
     val rule = MacrobenchmarkRule()
 
@@ -38,7 +37,7 @@ class StartupBenchmark {
         metrics = listOf(StartupTimingMetric()),
         compilationMode = compilationMode,
         experimentalConfig = ExperimentalConfig(
-            startupInsightsConfig = StartupInsightsConfig(isEnabled = true)
+            startupInsightsConfig = StartupInsightsConfig(isEnabled = true),
         ),
         startupMode = StartupMode.COLD,
         iterations = 10,
@@ -48,6 +47,6 @@ class StartupBenchmark {
         measureBlock = {
             startActivityAndWait()
             waitForHomeFeedContent()
-        }
+        },
     )
 }

--- a/android/feature/content-viewer/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/feature/contentviewer/SchemeAwareWebViewClient.kt
+++ b/android/feature/content-viewer/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/feature/contentviewer/SchemeAwareWebViewClient.kt
@@ -10,7 +10,7 @@ import co.touchlab.kermit.Logger
 internal class SchemeAwareWebViewClient : AccompanistWebViewClient() {
     override fun shouldOverrideUrlLoading(
         view: WebView?,
-        request: WebResourceRequest?
+        request: WebResourceRequest?,
     ): Boolean {
         request?.let {
             var url = it.url.toString()

--- a/android/feature/content-viewer/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/feature/contentviewer/WebView.kt
+++ b/android/feature/content-viewer/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/feature/contentviewer/WebView.kt
@@ -93,7 +93,7 @@ internal fun WebView(
             }
         val layoutParams = FrameLayout.LayoutParams(
             width,
-            height
+            height,
         )
 
         WebView(
@@ -106,7 +106,7 @@ internal fun WebView(
             onDispose,
             client,
             chromeClient,
-            factory
+            factory,
         )
     }
 }
@@ -175,14 +175,14 @@ internal fun WebView(
                             content.data,
                             content.mimeType,
                             content.encoding,
-                            content.historyUrl
+                            content.historyUrl,
                         )
                     }
 
                     is WebContent.Post -> {
                         wv.postUrl(
                             content.url,
-                            content.postData
+                            content.postData,
                         )
                     }
 
@@ -219,7 +219,7 @@ internal fun WebView(
         modifier = modifier,
         onRelease = {
             onDispose(it)
-        }
+        },
     )
 }
 
@@ -262,7 +262,7 @@ internal open class AccompanistWebViewClient : WebViewClient() {
     override fun onReceivedError(
         view: WebView,
         request: WebResourceRequest?,
-        error: WebResourceError?
+        error: WebResourceError?,
     ) {
         super.onReceivedError(view, request, error)
 
@@ -281,7 +281,6 @@ internal open class AccompanistWebViewClient : WebViewClient() {
  * class that can be overridden if further custom behaviour is required.
  */
 internal open class AccompanistWebChromeClient : WebChromeClient() {
-
     open lateinit var state: WebViewState
         internal set
 
@@ -314,12 +313,12 @@ internal sealed class WebContent {
         val baseUrl: String? = null,
         val encoding: String = "utf-8",
         val mimeType: String? = null,
-        val historyUrl: String? = null
+        val historyUrl: String? = null,
     ) : WebContent()
 
     data class Post(
         val url: String,
-        val postData: ByteArray
+        val postData: ByteArray,
     ) : WebContent() {
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
@@ -437,13 +436,16 @@ internal class WebViewState(webContent: WebContent) {
 internal class WebViewNavigator(private val coroutineScope: CoroutineScope) {
     private sealed interface NavigationEvent {
         data object Back : NavigationEvent
+
         data object Forward : NavigationEvent
+
         data object Reload : NavigationEvent
+
         data object StopLoading : NavigationEvent
 
         data class LoadUrl(
             val url: String,
-            val additionalHttpHeaders: Map<String, String> = emptyMap()
+            val additionalHttpHeaders: Map<String, String> = emptyMap(),
         ) : NavigationEvent
 
         data class LoadHtml(
@@ -451,12 +453,12 @@ internal class WebViewNavigator(private val coroutineScope: CoroutineScope) {
             val baseUrl: String? = null,
             val mimeType: String? = null,
             val encoding: String? = "utf-8",
-            val historyUrl: String? = null
+            val historyUrl: String? = null,
         ) : NavigationEvent
 
         data class PostUrl(
             val url: String,
-            val postData: ByteArray
+            val postData: ByteArray,
         ) : NavigationEvent {
             override fun equals(other: Any?): Boolean {
                 if (this === other) return true
@@ -491,7 +493,7 @@ internal class WebViewNavigator(private val coroutineScope: CoroutineScope) {
                     event.html,
                     event.mimeType,
                     event.encoding,
-                    event.historyUrl
+                    event.historyUrl,
                 )
 
                 is NavigationEvent.LoadUrl -> {
@@ -522,8 +524,8 @@ internal class WebViewNavigator(private val coroutineScope: CoroutineScope) {
             navigationEvents.emit(
                 NavigationEvent.LoadUrl(
                     url,
-                    additionalHttpHeaders
-                )
+                    additionalHttpHeaders,
+                ),
             )
         }
     }
@@ -533,7 +535,7 @@ internal class WebViewNavigator(private val coroutineScope: CoroutineScope) {
         baseUrl: String? = null,
         mimeType: String? = null,
         encoding: String? = "utf-8",
-        historyUrl: String? = null
+        historyUrl: String? = null,
     ) {
         coroutineScope.launch {
             navigationEvents.emit(
@@ -542,22 +544,22 @@ internal class WebViewNavigator(private val coroutineScope: CoroutineScope) {
                     baseUrl,
                     mimeType,
                     encoding,
-                    historyUrl
-                )
+                    historyUrl,
+                ),
             )
         }
     }
 
     fun postUrl(
         url: String,
-        postData: ByteArray
+        postData: ByteArray,
     ) {
         coroutineScope.launch {
             navigationEvents.emit(
                 NavigationEvent.PostUrl(
                     url,
-                    postData
-                )
+                    postData,
+                ),
             )
         }
     }
@@ -597,7 +599,7 @@ internal class WebViewNavigator(private val coroutineScope: CoroutineScope) {
  */
 @Composable
 internal fun rememberWebViewNavigator(
-    coroutineScope: CoroutineScope = rememberCoroutineScope()
+    coroutineScope: CoroutineScope = rememberCoroutineScope(),
 ): WebViewNavigator = remember(coroutineScope) { WebViewNavigator(coroutineScope) }
 
 /**
@@ -612,7 +614,7 @@ internal data class WebViewError(
     /**
      * The error that was reported.
      */
-    val error: WebResourceError
+    val error: WebResourceError,
 )
 
 /**
@@ -625,7 +627,7 @@ internal data class WebViewError(
 @Composable
 internal fun rememberWebViewState(
     url: String,
-    additionalHttpHeaders: Map<String, String> = emptyMap()
+    additionalHttpHeaders: Map<String, String> = emptyMap(),
 ): WebViewState =
 // Rather than using .apply {} here we will recreate the state, this prevents
     // a recomposition loop when the webview updates the url itself.
@@ -633,13 +635,13 @@ internal fun rememberWebViewState(
         WebViewState(
             WebContent.Url(
                 url = url,
-                additionalHttpHeaders = additionalHttpHeaders
-            )
+                additionalHttpHeaders = additionalHttpHeaders,
+            ),
         )
     }.apply {
         this.content = WebContent.Url(
             url = url,
-            additionalHttpHeaders = additionalHttpHeaders
+            additionalHttpHeaders = additionalHttpHeaders,
         )
     }
 
@@ -654,13 +656,17 @@ internal fun rememberWebViewStateWithHTMLData(
     baseUrl: String? = null,
     encoding: String = "utf-8",
     mimeType: String? = null,
-    historyUrl: String? = null
+    historyUrl: String? = null,
 ): WebViewState =
     remember {
         WebViewState(WebContent.Data(data, baseUrl, encoding, mimeType, historyUrl))
     }.apply {
         this.content = WebContent.Data(
-            data, baseUrl, encoding, mimeType, historyUrl
+            data,
+            baseUrl,
+            encoding,
+            mimeType,
+            historyUrl,
         )
     }
 
@@ -673,7 +679,7 @@ internal fun rememberWebViewStateWithHTMLData(
 @Composable
 internal fun rememberWebViewState(
     url: String,
-    postData: ByteArray
+    postData: ByteArray,
 ): WebViewState =
 // Rather than using .apply {} here we will recreate the state, this prevents
     // a recomposition loop when the webview updates the url itself.
@@ -681,13 +687,13 @@ internal fun rememberWebViewState(
         WebViewState(
             WebContent.Post(
                 url = url,
-                postData = postData
-            )
+                postData = postData,
+            ),
         )
     }.apply {
         this.content = WebContent.Post(
             url = url,
-            postData = postData
+            postData = postData,
         )
     }
 
@@ -714,7 +720,7 @@ internal val WebStateSaver: Saver<WebViewState, Any> = run {
             mapOf(
                 pageTitleKey to it.pageTitle,
                 lastLoadedUrlKey to it.lastLoadedUrl,
-                stateBundle to viewState
+                stateBundle to viewState,
             )
         },
         restore = {
@@ -723,6 +729,6 @@ internal val WebStateSaver: Saver<WebViewState, Any> = run {
                 this.lastLoadedUrl = it[lastLoadedUrlKey] as String?
                 this.viewState = it[stateBundle] as Bundle?
             }
-        }
+        },
     )
 }

--- a/android/feature/home/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/feature/home/HomeScreen.kt
+++ b/android/feature/home/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/feature/home/HomeScreen.kt
@@ -130,7 +130,7 @@ internal fun SharedTransitionScope.HomeScreen(
                     syncing = (uiState is HomeUiState.Content && uiState.refreshing),
                     onClick = { eventSink(HomeUiEvent.Refresh) },
                 )
-            }
+            },
         )
 
         Box {

--- a/android/feature/home/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/feature/home/component/TransientErrorBanner.kt
+++ b/android/feature/home/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/feature/home/component/TransientErrorBanner.kt
@@ -79,7 +79,7 @@ private fun DismissButton(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = null,
             ),
-        contentAlignment = Alignment.Center
+        contentAlignment = Alignment.Center,
     ) {
         Icon(
             imageVector = KSIcons.Close,

--- a/android/feature/home/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/home/HomeScreenTest.kt
+++ b/android/feature/home/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/home/HomeScreenTest.kt
@@ -20,7 +20,6 @@ import kotlin.time.Instant
 
 @RunWith(ThemeVariantInjector::class)
 class HomeScreenTest {
-
     @get:Rule
     val snapshotTester = SnapshotTester()
 
@@ -28,7 +27,7 @@ class HomeScreenTest {
     fun snapshot_HomeScreen_Loading() {
         snapshotTester.snapshot {
             HomeScreenSnapshot(
-                uiState = HomeUiState.Loading
+                uiState = HomeUiState.Loading,
             )
         }
     }
@@ -53,7 +52,7 @@ class HomeScreenTest {
                                     description = "Welcome to another engaging episode of Talking Kotlin! In this edition, we dive into the dynamic world of Android development with Colin White, the creator of the widely acclaimed Coil library. Join us as we discuss the latest developments, insights, and the exciting roadmap for Coil. \uD83D\uDE80 Highlights from this Episode: Learn about Colin's journey in developing the Coil library. Discover the pivotal role Coil plays in simplifying image loading for Android developers. Get an exclusive sneak peek into the upcoming Coil 3.0, featuring multi-platform support and seamless integration with Jetpack Compose. \uD83D\uDD17 Helpful Links: Coil Library GitHub: https://coil-kt.github.io/coil/ Follow Colin White on Twitter: https://twitter.com/colinwhi \uD83C\uDF10 Connect with the Kotlin Community: https://kotlinlang.org/community/ Kotlin Foundation: https://kotlinfoundation.org/ \uD83D\uDC49 Don't miss out on the latest insights and updates from the Kotlin world! Subscribe, hit the bell icon, and join the conversation in the comments below. \uD83D\uDCC8 Help us reach 20,000 views by liking, sharing, and subscribing! Your support keeps the Kotlin conversation alive.",
                                 ),
                                 displayablePublishTime = "Moments ago",
-                            )
+                            ),
                         ),
                         HomeFeedItem.Item(
                             displayableFeedItem = DisplayableFeedItem(
@@ -85,12 +84,12 @@ class HomeScreenTest {
                                     startPositionMillis = 0,
                                 ),
                                 displayablePublishTime = "6 days ago",
-                            )
-                        )
+                            ),
+                        ),
                     ),
                     refreshing = false,
                     hasTransientError = false,
-                )
+                ),
             )
         }
     }

--- a/android/feature/home/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/home/component/FeedFilterChipTest.kt
+++ b/android/feature/home/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/home/component/FeedFilterChipTest.kt
@@ -11,7 +11,6 @@ import org.junit.runner.RunWith
 
 @RunWith(ThemeVariantInjector::class)
 class FeedFilterChipTest {
-
     @get:Rule
     val snapshotTester = SnapshotTester()
 

--- a/android/feature/home/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/home/component/SyncButtonTest.kt
+++ b/android/feature/home/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/home/component/SyncButtonTest.kt
@@ -11,7 +11,6 @@ import org.junit.runner.RunWith
 
 @RunWith(ThemeVariantInjector::class)
 class SyncButtonTest {
-
     @get:Rule
     val snapshotTester = SnapshotTester()
 

--- a/android/feature/home/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/home/component/TransientErrorBannerTest.kt
+++ b/android/feature/home/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/home/component/TransientErrorBannerTest.kt
@@ -11,7 +11,6 @@ import org.junit.runner.RunWith
 
 @RunWith(ThemeVariantInjector::class)
 class TransientErrorBannerTest {
-
     @get:Rule
     val snapshotTester = SnapshotTester()
 

--- a/android/feature/kotlin-weekly-issue/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/feature/kotlinweeklyissue/component/IssueGroupUi.kt
+++ b/android/feature/kotlin-weekly-issue/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/feature/kotlinweeklyissue/component/IssueGroupUi.kt
@@ -47,7 +47,7 @@ internal fun IssueGroupUi(
                 bottom = 8.dp,
                 start = 24.dp,
                 end = 24.dp,
-            )
+            ),
         )
     }
 }
@@ -89,7 +89,7 @@ private val LibrariesColor = Color(0xFF800000)
 @Composable
 @PreviewLightDark
 private fun PreviewIssueGroupBadge(
-    @PreviewParameter(IssueGroupProvider::class) issueGroup: KotlinWeeklyIssueItem.Group
+    @PreviewParameter(IssueGroupProvider::class) issueGroup: KotlinWeeklyIssueItem.Group,
 ) {
     KSTheme {
         Surface {

--- a/android/feature/kotlin-weekly-issue/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/feature/kotlinweeklyissue/component/IssueItemUi.kt
+++ b/android/feature/kotlin-weekly-issue/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/feature/kotlinweeklyissue/component/IssueItemUi.kt
@@ -34,7 +34,7 @@ internal fun IssueItemUi(
             Text(
                 text = item.title,
                 style = KSTheme.typography.titleMedium.copy(
-                    fontWeight = FontWeight.ExtraBold
+                    fontWeight = FontWeight.ExtraBold,
                 ),
                 color = KSTheme.colorScheme.onBackgroundVariant,
             )

--- a/android/feature/kotlin-weekly-issue/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/kotlinweeklyissue/component/IssueGroupUiTest.kt
+++ b/android/feature/kotlin-weekly-issue/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/kotlinweeklyissue/component/IssueGroupUiTest.kt
@@ -9,7 +9,6 @@ import org.junit.Test
 
 @Burst
 class IssueGroupUiTest {
-
     @get:Rule
     val snapshotTester = SnapshotTester()
 

--- a/android/feature/kotlin-weekly-issue/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/kotlinweeklyissue/component/IssueItemUiTest.kt
+++ b/android/feature/kotlin-weekly-issue/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/kotlinweeklyissue/component/IssueItemUiTest.kt
@@ -9,7 +9,6 @@ import org.junit.runner.RunWith
 
 @RunWith(ThemeVariantInjector::class)
 class IssueItemUiTest {
-
     @get:Rule
     val snapshotTester = SnapshotTester()
 

--- a/android/feature/kotlin-weekly-issue/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/kotlinweeklyissue/component/KotlinWeeklyIssueScreenTest.kt
+++ b/android/feature/kotlin-weekly-issue/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/kotlinweeklyissue/component/KotlinWeeklyIssueScreenTest.kt
@@ -14,7 +14,6 @@ import org.junit.runner.RunWith
 
 @RunWith(ThemeVariantInjector::class)
 class KotlinWeeklyIssueScreenTest {
-
     @get:Rule
     val snapshotTester = SnapshotTester()
 
@@ -41,8 +40,8 @@ class KotlinWeeklyIssueScreenTest {
                                 summary = "The Kotlin Foundation is once again participating in Google Summer of Code. If you are thinking of participating, check out this announcement.",
                                 url = "url",
                                 source = "blog.jetbrains.com",
-                                group = KotlinWeeklyIssueItem.Group.Announcements
-                            )
+                                group = KotlinWeeklyIssueItem.Group.Announcements,
+                            ),
                         ),
                         KotlinWeeklyIssueItem.Group.Articles to listOf(
                             KotlinWeeklyIssueItem(
@@ -50,8 +49,8 @@ class KotlinWeeklyIssueScreenTest {
                                 summary = "Watch out when you are using List, Map, Set, etc in Compose. Jorge Castillo explains what strong skipping in Compose does not fix.",
                                 url = "url",
                                 source = "newsletter.jorgecastillo.dev",
-                                group = KotlinWeeklyIssueItem.Group.Articles
-                            )
+                                group = KotlinWeeklyIssueItem.Group.Articles,
+                            ),
                         ),
                         KotlinWeeklyIssueItem.Group.Videos to listOf(
                             KotlinWeeklyIssueItem(
@@ -59,11 +58,11 @@ class KotlinWeeklyIssueScreenTest {
                                 summary = "Piotr from Codersee explains in this video how to integrate a Ktor application with the MongoDB database and Kotlin coroutines.",
                                 url = "url",
                                 source = "www.youtube.com",
-                                group = KotlinWeeklyIssueItem.Group.Videos
-                            )
+                                group = KotlinWeeklyIssueItem.Group.Videos,
+                            ),
                         ),
                     ),
-                    savedForLater = true
+                    savedForLater = true,
                 ),
             )
         }

--- a/android/feature/saved-for-later/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/savedforlater/SavedForLaterScreenTest.kt
+++ b/android/feature/saved-for-later/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/savedforlater/SavedForLaterScreenTest.kt
@@ -19,7 +19,6 @@ import kotlin.time.Instant
 
 @RunWith(ThemeVariantInjector::class)
 class SavedForLaterScreenTest {
-
     @get:Rule
     val snapshotTester = SnapshotTester()
 
@@ -79,9 +78,9 @@ class SavedForLaterScreenTest {
                                 description = "JetBrains Kotlin Multiplatform (KMP) is an open-source technology",
                             ),
                             displayablePublishTime = "21 Nov 2023",
-                        )
+                        ),
                     ),
-                )
+                ),
             )
         }
     }

--- a/android/feature/talking-kotlin-episode/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/feature/talkingkotlinepisode/TalkingKotlinEpisodeScreen.kt
+++ b/android/feature/talking-kotlin-episode/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/feature/talkingkotlinepisode/TalkingKotlinEpisodeScreen.kt
@@ -290,7 +290,7 @@ private fun SharedTransitionScope.ContentUi(
                         Text(
                             text = stringResource(id = R.string.episode_website),
                             style = KSTheme.typography.labelLarge.copy(
-                                fontWeight = FontWeight.ExtraBold
+                                fontWeight = FontWeight.ExtraBold,
                             ),
                         )
                         Spacer(modifier = Modifier.weight(1f))

--- a/android/feature/talking-kotlin-episode/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/feature/talkingkotlinepisode/component/AudioPlayer.kt
+++ b/android/feature/talking-kotlin-episode/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/feature/talkingkotlinepisode/component/AudioPlayer.kt
@@ -19,11 +19,17 @@ import androidx.media3.extractor.mp3.Mp3Extractor
 
 internal interface AudioPlayer {
     fun play()
+
     fun pause()
+
     fun stop()
+
     fun seekTo(position: Long)
+
     fun release()
+
     val currentPosition: Long
+
     val duration: Long
 }
 
@@ -40,7 +46,7 @@ internal fun rememberAudioPlayer(
         if (!localInspectionMode) {
             val audioOnlyRenderersFactory = RenderersFactory { handler, _, audioListener, _, _ ->
                 arrayOf<Renderer>(
-                    MediaCodecAudioRenderer(context, MediaCodecSelector.DEFAULT, handler, audioListener)
+                    MediaCodecAudioRenderer(context, MediaCodecSelector.DEFAULT, handler, audioListener),
                 )
             }
             val extractorFactory = ExtractorsFactory {
@@ -49,7 +55,7 @@ internal fun rememberAudioPlayer(
             val exoPlayer = ExoPlayer.Builder(
                 context,
                 audioOnlyRenderersFactory,
-                DefaultMediaSourceFactory(context, extractorFactory)
+                DefaultMediaSourceFactory(context, extractorFactory),
             ).build().apply {
                 setMediaItem(MediaItem.fromUri(audioUrl))
                 prepare()
@@ -74,11 +80,17 @@ internal fun rememberAudioPlayer(
         } else {
             object : AudioPlayer {
                 override fun play() = Unit
+
                 override fun pause() = Unit
+
                 override fun stop() = Unit
+
                 override fun seekTo(position: Long) = Unit
+
                 override fun release() = Unit
+
                 override val currentPosition: Long = 0
+
                 override val duration: Long = 0
             }
         }

--- a/android/feature/talking-kotlin-episode/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/feature/talkingkotlinepisode/component/PlayPauseButton.kt
+++ b/android/feature/talking-kotlin-episode/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/feature/talkingkotlinepisode/component/PlayPauseButton.kt
@@ -59,10 +59,10 @@ internal fun PlayPauseButton(
             ) { playing ->
                 Text(
                     text = stringResource(
-                        id = if (playing) R.string.pause else R.string.play
+                        id = if (playing) R.string.pause else R.string.play,
                     ),
                     style = KSTheme.typography.labelLarge.copy(
-                        fontWeight = FontWeight.ExtraBold
+                        fontWeight = FontWeight.ExtraBold,
                     ),
                 )
             }

--- a/android/feature/talking-kotlin-episode/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/feature/talkingkotlinepisode/component/SeekBar.kt
+++ b/android/feature/talking-kotlin-episode/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/feature/talkingkotlinepisode/component/SeekBar.kt
@@ -88,7 +88,7 @@ internal fun SeekBar(
                                 },
                                 onTap = {
                                     seeking = false
-                                }
+                                },
                             )
                         }
                         .pointerInput(Unit) {
@@ -108,7 +108,7 @@ internal fun SeekBar(
                         }
                 } else {
                     Modifier
-                }
+                },
             ),
     ) {
         Layout(
@@ -123,7 +123,7 @@ internal fun SeekBar(
                 Canvas(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(trackHeight)
+                        .height(trackHeight),
                 ) {
                     drawRect(
                         color = inactiveColor,
@@ -137,7 +137,7 @@ internal fun SeekBar(
             },
             modifier = Modifier
                 .fillMaxWidth()
-                .clip(CircleShape)
+                .clip(CircleShape),
         ) { measurables, constraints ->
             val trackPlaceable = measurables.first().measure(constraints)
             if (!seeking) {
@@ -151,7 +151,7 @@ internal fun SeekBar(
         Row(
             modifier = Modifier.offset {
                 IntOffset(0, timeLabelsOffsetPx.roundToInt())
-            }
+            },
         ) {
             val (playedProgress, remainingProgress) = playbackProgressLabels(currentPositionMillis, durationMillis)
             Text(
@@ -203,7 +203,7 @@ private const val AnimationDurationMillis = 400
 private fun PreviewSeekBar() {
     KSTheme {
         Surface(
-            color = KSTheme.colorScheme.tertiary
+            color = KSTheme.colorScheme.tertiary,
         ) {
             SeekBar(
                 modifier = Modifier.padding(8.dp),

--- a/android/feature/talking-kotlin-episode/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/talkingkotlinepisode/TalkingKotlinEpisodeScreenTest.kt
+++ b/android/feature/talking-kotlin-episode/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/talkingkotlinepisode/TalkingKotlinEpisodeScreenTest.kt
@@ -13,7 +13,6 @@ import org.junit.runner.RunWith
 
 @RunWith(ThemeVariantInjector::class)
 class TalkingKotlinEpisodeScreenTest {
-
     @get:Rule
     val snapshotTester = SnapshotTester()
 

--- a/android/feature/talking-kotlin-episode/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/talkingkotlinepisode/component/PlayPauseButtonTest.kt
+++ b/android/feature/talking-kotlin-episode/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/talkingkotlinepisode/component/PlayPauseButtonTest.kt
@@ -11,7 +11,6 @@ import org.junit.runner.RunWith
 
 @RunWith(ThemeVariantInjector::class)
 class PlayPauseButtonTest {
-
     @get:Rule
     val snapshotTester = SnapshotTester()
 

--- a/android/feature/talking-kotlin-episode/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/talkingkotlinepisode/component/PlaybackProgressLabelsTest.kt
+++ b/android/feature/talking-kotlin-episode/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/talkingkotlinepisode/component/PlaybackProgressLabelsTest.kt
@@ -4,7 +4,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class PlaybackProgressLabelsTest {
-
     @Test
     fun `test playback progress labels`() {
         assertEquals("00:00:00" to "-00:00:00", playbackProgressLabels(0, 0))

--- a/android/feature/talking-kotlin-episode/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/talkingkotlinepisode/component/PodcastPlayerUiTest.kt
+++ b/android/feature/talking-kotlin-episode/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/talkingkotlinepisode/component/PodcastPlayerUiTest.kt
@@ -12,7 +12,6 @@ import org.junit.runner.RunWith
 
 @RunWith(ThemeVariantInjector::class)
 class PodcastPlayerUiTest {
-
     @get:Rule
     val snapshotTester = SnapshotTester()
 

--- a/android/feature/talking-kotlin-episode/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/talkingkotlinepisode/component/SeekBarTest.kt
+++ b/android/feature/talking-kotlin-episode/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/feature/talkingkotlinepisode/component/SeekBarTest.kt
@@ -13,7 +13,6 @@ import org.junit.runner.RunWith
 
 @RunWith(ThemeVariantInjector::class)
 class SeekBarTest {
-
     @get:Rule
     val snapshotTester = SnapshotTester()
 
@@ -21,7 +20,7 @@ class SeekBarTest {
     fun snapshot_SeekBar() {
         snapshotTester.snapshot(addSurface = false) {
             Surface(
-                color = KSTheme.colorScheme.tertiary
+                color = KSTheme.colorScheme.tertiary,
             ) {
                 SeekBar(
                     modifier = Modifier.padding(8.dp),

--- a/android/foundation/common-ui/feed/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/commonui/feed/TalkingKotlinCard.kt
+++ b/android/foundation/common-ui/feed/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/commonui/feed/TalkingKotlinCard.kt
@@ -77,7 +77,7 @@ public fun SharedTransitionScope.TalkingKotlinCard(
                     )
                 } else {
                     Modifier
-                }
+                },
             )
             .drawBehind {
                 drawRoundRect(
@@ -96,7 +96,7 @@ public fun SharedTransitionScope.TalkingKotlinCard(
                 end = 8.dp,
                 top = 16.dp,
                 bottom = 16.dp,
-            )
+            ),
         ) {
             Row {
                 Column(
@@ -148,36 +148,47 @@ public fun SharedTransitionScope.TalkingKotlinCard(
                 )
             }
             Spacer(modifier = Modifier.height(8.dp))
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Surface(
-                    shape = CircleShape,
-                    color = KSTheme.colorScheme.containerOnTertiary,
-                    contentColor = KSTheme.colorScheme.primary,
-                ) {
-                    Text(
-                        text = item.value.duration,
-                        style = KSTheme.typography.labelMedium.copy(
-                            fontWeight = FontWeight.ExtraBold,
-                        ),
-                        modifier = Modifier.padding(
-                            vertical = 8.dp,
-                            horizontal = 12.dp,
-                        ),
-                    )
-                }
-                Spacer(modifier = Modifier.weight(1f))
-                IconButton(
-                    if (item.value.savedForLater) {
-                        KSIcons.BookmarkFill
-                    } else {
-                        KSIcons.BookmarkAdd
-                    },
-                    contentDescription = null,
-                    onClick = { onSaveButtonClick(item.value) },
-                    modifier = Modifier.testTag("saveButton"),
-                )
-            }
+            BottomRow(
+                item = item,
+                onSaveButtonClick = onSaveButtonClick,
+            )
         }
+    }
+}
+
+@Composable
+private fun BottomRow(
+    item: DisplayableFeedItem<FeedItem.TalkingKotlin>,
+    onSaveButtonClick: (FeedItem.TalkingKotlin) -> Unit,
+) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Surface(
+            shape = CircleShape,
+            color = KSTheme.colorScheme.containerOnTertiary,
+            contentColor = KSTheme.colorScheme.primary,
+        ) {
+            Text(
+                text = item.value.duration,
+                style = KSTheme.typography.labelMedium.copy(
+                    fontWeight = FontWeight.ExtraBold,
+                ),
+                modifier = Modifier.padding(
+                    vertical = 8.dp,
+                    horizontal = 12.dp,
+                ),
+            )
+        }
+        Spacer(modifier = Modifier.weight(1f))
+        IconButton(
+            if (item.value.savedForLater) {
+                KSIcons.BookmarkFill
+            } else {
+                KSIcons.BookmarkAdd
+            },
+            contentDescription = null,
+            onClick = { onSaveButtonClick(item.value) },
+            modifier = Modifier.testTag("saveButton"),
+        )
     }
 }
 

--- a/android/foundation/common-ui/feed/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/commonui/feed/KotlinBlogCardTest.kt
+++ b/android/foundation/common-ui/feed/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/commonui/feed/KotlinBlogCardTest.kt
@@ -17,7 +17,6 @@ import kotlin.time.Instant
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Burst
 class KotlinBlogCardTest {
-
     @get:Rule
     val snapshotTester = SnapshotTester()
 

--- a/android/foundation/common-ui/feed/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/commonui/feed/KotlinWeeklyCardTest.kt
+++ b/android/foundation/common-ui/feed/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/commonui/feed/KotlinWeeklyCardTest.kt
@@ -14,7 +14,6 @@ import kotlin.time.Instant
 
 @Burst
 class KotlinWeeklyCardTest {
-
     @get:Rule
     val snapshotTester = SnapshotTester()
 

--- a/android/foundation/common-ui/feed/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/commonui/feed/KotlinYouTubeCardTest.kt
+++ b/android/foundation/common-ui/feed/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/commonui/feed/KotlinYouTubeCardTest.kt
@@ -17,7 +17,6 @@ import kotlin.time.Instant
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Burst
 class KotlinYouTubeCardTest {
-
     @get:Rule
     val snapshotTester = SnapshotTester()
 

--- a/android/foundation/common-ui/feed/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/commonui/feed/TalkingKotlinCardTest.kt
+++ b/android/foundation/common-ui/feed/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/commonui/feed/TalkingKotlinCardTest.kt
@@ -17,7 +17,6 @@ import kotlin.time.Instant
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Burst
 class TalkingKotlinCardTest {
-
     @get:Rule
     val snapshotTester = SnapshotTester()
 

--- a/android/foundation/compose-utils/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/composeutils/linkify.kt
+++ b/android/foundation/compose-utils/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/composeutils/linkify.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.text.buildAnnotatedString
  * Adopted from https://stackoverflow.com/a/73662287
  */
 public fun String.linkify(
-    linkStyle: SpanStyle
+    linkStyle: SpanStyle,
 ): AnnotatedString = buildAnnotatedString {
     append(this@linkify)
     val spannable = SpannableString(this@linkify)

--- a/android/foundation/compose-utils/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/composeutils/marquee.kt
+++ b/android/foundation/compose-utils/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/composeutils/marquee.kt
@@ -34,7 +34,9 @@ public fun Modifier.marqueeWithFadedEdges(
 ): Modifier = if (fadedEdgeMode != FadedEdgeMode.None) {
     offset(x = -startEdgePadding)
         .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen }
-} else { this }
+} else {
+    this
+}
     .drawWithContent {
         drawContent()
         when (fadedEdgeMode) {
@@ -68,19 +70,18 @@ public fun Modifier.marqueeWithFadedEdges(
         repeatDelayMillis = repeatDelayMillis,
         initialDelayMillis = initialDelayMillis,
         spacing = spacing,
-        velocity = velocity
+        velocity = velocity,
     )
     .then(
         if (fadedEdgeMode != FadedEdgeMode.None) {
             Modifier.padding(start = startEdgePadding)
         } else {
             Modifier
-        }
+        },
     )
 
 @JvmInline
 public value class FadedEdgeMode private constructor(private val value: Int) {
-
     override fun toString(): String = when (this) {
         Both -> "Both"
         Start -> "Start"
@@ -90,7 +91,6 @@ public value class FadedEdgeMode private constructor(private val value: Int) {
     }
 
     public companion object {
-
         public val Both: FadedEdgeMode = FadedEdgeMode(0)
 
         public val Start: FadedEdgeMode = FadedEdgeMode(1)
@@ -114,8 +114,8 @@ private fun ContentDrawScope.drawFadedEdge(
         brush = Brush.horizontalGradient(
             colors = listOf(Color.Transparent, Color.Black),
             startX = if (leftEdge) 0f else size.width,
-            endX = if (leftEdge) edgeWidthPx else size.width - edgeWidthPx
+            endX = if (leftEdge) edgeWidthPx else size.width - edgeWidthPx,
         ),
-        blendMode = BlendMode.DstIn
+        blendMode = BlendMode.DstIn,
     )
 }

--- a/android/foundation/designsystem/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/Button.kt
+++ b/android/foundation/designsystem/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/Button.kt
@@ -42,7 +42,7 @@ public fun Button(
             Text(
                 text = text.uppercase(),
                 style = KSTheme.typography.labelLarge.copy(
-                    fontWeight = FontWeight.ExtraBold
+                    fontWeight = FontWeight.ExtraBold,
                 ),
             )
         }

--- a/android/foundation/designsystem/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/IconButton.kt
+++ b/android/foundation/designsystem/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/IconButton.kt
@@ -95,10 +95,10 @@ private fun IconButtonImpl(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = ripple(
                     bounded = false,
-                    radius = containerSize / 2
-                )
+                    radius = containerSize / 2,
+                ),
             ),
-        contentAlignment = Alignment.Center
+        contentAlignment = Alignment.Center,
     ) {
         Icon(
             imageVector = imageVector,
@@ -129,7 +129,7 @@ public fun FilledIconButton(
     ) {
         Box(
             modifier = Modifier.size(DefaultContainerSize),
-            contentAlignment = Alignment.Center
+            contentAlignment = Alignment.Center,
         ) {
             Icon(
                 imageVector = imageVector,

--- a/android/foundation/designsystem/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/Surface.kt
+++ b/android/foundation/designsystem/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/Surface.kt
@@ -23,7 +23,7 @@ public fun Surface(
     contentColor: Color = KSTheme.colorScheme.onBackground,
     border: BorderStroke? = null,
     elevation: Dp = 0.dp,
-    content: @Composable () -> Unit
+    content: @Composable () -> Unit,
 ) {
     CompositionLocalProvider(LocalContentColor provides contentColor) {
         MaterialSurface(
@@ -50,7 +50,7 @@ public fun Surface(
     contentColor: Color = KSTheme.colorScheme.onBackground,
     elevation: Dp = 0.dp,
     border: BorderStroke? = null,
-    content: @Composable () -> Unit
+    content: @Composable () -> Unit,
 ) {
     CompositionLocalProvider(LocalContentColor provides contentColor) {
         MaterialSurface(

--- a/android/foundation/designsystem/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/Text.kt
+++ b/android/foundation/designsystem/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/Text.kt
@@ -38,7 +38,7 @@ public fun Text(
             color = textColor,
             textAlign = textAlign,
             textDecoration = textDecoration,
-        )
+        ),
     )
     BasicText(
         text,
@@ -77,7 +77,7 @@ public fun Text(
             color = textColor,
             textAlign = textAlign,
             textDecoration = textDecoration,
-        )
+        ),
     )
     BasicText(
         text = text,

--- a/android/foundation/designsystem/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/TopNavBar.kt
+++ b/android/foundation/designsystem/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/TopNavBar.kt
@@ -58,14 +58,14 @@ public fun SharedTransitionScope.TopNavBar(
                     )
                 } else {
                     Modifier
-                }
+                },
             ),
         elevation = elevation,
         color = KSTheme.colorScheme.background,
         contentColor = KSTheme.colorScheme.primary,
     ) {
         Box(
-            modifier = Modifier.padding(contentPadding)
+            modifier = Modifier.padding(contentPadding),
         ) {
             Column(
                 modifier = Modifier.padding(vertical = 16.dp),
@@ -86,7 +86,7 @@ public fun SharedTransitionScope.TopNavBar(
                         animatedVisibilityScope = animatedVisibilityScope,
                         titleElementKey = titleElementKey,
                         text = title,
-                        modifier = Modifier.weight(1f)
+                        modifier = Modifier.weight(1f),
                     )
 
                     actions()
@@ -145,7 +145,7 @@ private fun SharedTransitionScope.GradientTitle(
                     .skipToLookaheadSize()
             } else {
                 Modifier
-            }
+            },
         )
     }
 }
@@ -198,11 +198,11 @@ private fun PreviewTopNavBar_withBottomRow() {
                                 style = KSTheme.typography.labelMedium.copy(
                                     fontWeight = FontWeight.ExtraBold,
                                     letterSpacing = 0.sp,
-                                )
+                                ),
                             )
                             Icon(KSIcons.ArrowDown, contentDescription = null)
                         }
-                    }
+                    },
                 )
             }
         }

--- a/android/foundation/designsystem/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/foundation/KSTheme.kt
+++ b/android/foundation/designsystem/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/foundation/KSTheme.kt
@@ -16,7 +16,7 @@ import io.github.reactivecircus.kstreamlined.android.foundation.designsystem.fou
 @Composable
 public fun KSTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
-    content: @Composable () -> Unit
+    content: @Composable () -> Unit,
 ) {
     val colorScheme = if (darkTheme) {
         DarkColorScheme

--- a/android/foundation/designsystem/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/foundation/icon/Kotlin.kt
+++ b/android/foundation/designsystem/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/foundation/icon/Kotlin.kt
@@ -15,7 +15,7 @@ public val KSIcons.Kotlin: ImageVector
                     "M22 22H2V2H22L12 12L22 22Z",
                     DefaultFillType,
                 ),
-            )
+            ),
         )
         return _kotlin!!
     }

--- a/android/foundation/designsystem/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/ButtonTest.kt
+++ b/android/foundation/designsystem/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/ButtonTest.kt
@@ -11,7 +11,6 @@ import org.junit.runner.RunWith
 
 @RunWith(ThemeVariantInjector::class)
 class ButtonTest {
-
     @get:Rule
     val snapshotTester = SnapshotTester()
 

--- a/android/foundation/designsystem/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/ChipTest.kt
+++ b/android/foundation/designsystem/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/ChipTest.kt
@@ -13,7 +13,6 @@ import org.junit.runner.RunWith
 
 @RunWith(ThemeVariantInjector::class)
 class ChipTest {
-
     @get:Rule
     val snapshotTester = SnapshotTester()
 

--- a/android/foundation/designsystem/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/DividerTest.kt
+++ b/android/foundation/designsystem/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/DividerTest.kt
@@ -18,7 +18,6 @@ import org.junit.runner.RunWith
 
 @RunWith(ThemeVariantInjector::class)
 class DividerTest {
-
     @get:Rule
     val snapshotTester = SnapshotTester()
 

--- a/android/foundation/designsystem/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/IconButtonTest.kt
+++ b/android/foundation/designsystem/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/IconButtonTest.kt
@@ -14,7 +14,6 @@ import org.junit.runner.RunWith
 
 @RunWith(ThemeVariantInjector::class)
 class IconButtonTest {
-
     @get:Rule
     val snapshotTester = SnapshotTester()
 

--- a/android/foundation/designsystem/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/LoadingIndicatorTest.kt
+++ b/android/foundation/designsystem/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/LoadingIndicatorTest.kt
@@ -11,7 +11,6 @@ import org.junit.runner.RunWith
 
 @RunWith(ThemeVariantInjector::class)
 class LoadingIndicatorTest {
-
     @get:Rule
     val snapshotTester = SnapshotTester()
 

--- a/android/foundation/designsystem/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/NavigationIslandTest.kt
+++ b/android/foundation/designsystem/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/NavigationIslandTest.kt
@@ -14,7 +14,6 @@ import org.junit.runner.RunWith
 
 @RunWith(ThemeVariantInjector::class)
 class NavigationIslandTest {
-
     @get:Rule
     val snapshotTester = SnapshotTester()
 

--- a/android/foundation/designsystem/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/TopNavBarTest.kt
+++ b/android/foundation/designsystem/src/test/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/designsystem/component/TopNavBarTest.kt
@@ -15,7 +15,6 @@ import org.junit.runner.RunWith
 @OptIn(ExperimentalSharedTransitionApi::class)
 @RunWith(ThemeVariantInjector::class)
 class TopNavBarTest {
-
     @get:Rule
     val snapshotTester = SnapshotTester()
 
@@ -60,11 +59,11 @@ class TopNavBarTest {
                                 style = KSTheme.typography.labelMedium.copy(
                                     fontWeight = FontWeight.ExtraBold,
                                     letterSpacing = 0.sp,
-                                )
+                                ),
                             )
                             Icon(KSIcons.ArrowDown, contentDescription = null)
                         }
-                    }
+                    },
                 )
             }
         }

--- a/android/foundation/scheduled-work/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/scheduledwork/WorkScheduler.kt
+++ b/android/foundation/scheduled-work/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/scheduledwork/WorkScheduler.kt
@@ -15,7 +15,7 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.toJavaDuration
 
 public class WorkScheduler @Inject constructor(
-    @param:ApplicationContext private val context: Context
+    @param:ApplicationContext private val context: Context,
 ) {
     public fun schedule() {
         scheduleSync()

--- a/android/foundation/scheduled-work/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/scheduledwork/sync/SyncWorker.kt
+++ b/android/foundation/scheduled-work/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/scheduledwork/sync/SyncWorker.kt
@@ -15,7 +15,6 @@ internal class SyncWorker @AssistedInject constructor(
     @Assisted workerParams: WorkerParameters,
     private val feedSyncEngine: FeedSyncEngine,
 ) : CoroutineWorker(appContext, workerParams) {
-
     override suspend fun doWork(): Result = traceAsync("ScheduledSync", 0) {
         feedSyncEngine.sync()
         Result.success()

--- a/android/foundation/screenshot-testing/tester/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/screenshottesting/tester/SnapshotTester.kt
+++ b/android/foundation/screenshot-testing/tester/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/screenshottesting/tester/SnapshotTester.kt
@@ -23,6 +23,8 @@ public class SnapshotTester(
 ) {
     private lateinit var description: Description
 
+    private var currentThemeVariant: ThemeVariant? = null
+
     override fun apply(base: Statement, description: Description): Statement {
         this.description = description
         return object : Statement() {
@@ -31,8 +33,6 @@ public class SnapshotTester(
             }
         }
     }
-
-    private var currentThemeVariant: ThemeVariant? = null
 
     internal fun setCurrentThemeVariant(themeVariant: ThemeVariant) {
         currentThemeVariant = themeVariant

--- a/android/foundation/screenshot-testing/tester/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/screenshottesting/tester/ThemeVariantInjector.kt
+++ b/android/foundation/screenshot-testing/tester/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/foundation/screenshottesting/tester/ThemeVariantInjector.kt
@@ -13,7 +13,6 @@ import java.lang.reflect.Field
  * A test runner that runs snapshot tests with both Light and Dark theme variants.
  */
 public class ThemeVariantInjector(private val testClass: Class<*>) : Runner() {
-
     private val delegate: BlockJUnit4ClassRunner
 
     init {
@@ -33,7 +32,7 @@ public class ThemeVariantInjector(private val testClass: Class<*>) : Runner() {
                     return if (method is ThemeVariantMethod) {
                         Description.createTestDescription(
                             testClass.name,
-                            "${method.delegate.name}[${method.variant.name}]"
+                            "${method.delegate.name}[${method.variant.name}]",
                         )
                     } else {
                         super.describeChild(method)
@@ -45,7 +44,7 @@ public class ThemeVariantInjector(private val testClass: Class<*>) : Runner() {
                         ThemeVariantStatement(
                             super.methodInvoker(method.delegate, test),
                             test,
-                            method.variant
+                            method.variant,
                         )
                     } else {
                         super.methodInvoker(method, test)
@@ -62,18 +61,13 @@ public class ThemeVariantInjector(private val testClass: Class<*>) : Runner() {
         delegate.run(notifier)
     }
 
-    override fun getDescription(): Description {
-        return delegate.description
-    }
+    override fun getDescription(): Description = delegate.description
 
     private class ThemeVariantMethod(
         val delegate: FrameworkMethod,
-        val variant: ThemeVariant
+        val variant: ThemeVariant,
     ) : FrameworkMethod(delegate.method) {
-
-        override fun getName(): String {
-            return "${delegate.name}[${variant.name}]"
-        }
+        override fun getName(): String = "${delegate.name}[${variant.name}]"
 
         override fun validatePublicVoidNoArg(isStatic: Boolean, errors: MutableList<Throwable>) {
             delegate.validatePublicVoidNoArg(isStatic, errors)
@@ -83,9 +77,8 @@ public class ThemeVariantInjector(private val testClass: Class<*>) : Runner() {
     private class ThemeVariantStatement(
         private val delegate: Statement,
         private val testInstance: Any,
-        private val variant: ThemeVariant
+        private val variant: ThemeVariant,
     ) : Statement() {
-
         override fun evaluate() {
             val testerFields = findSnapshotTesterFields(testInstance)
             testerFields.forEach { field ->

--- a/build-logic/kstreamlined-gradle-plugin/build.gradle.kts
+++ b/build-logic/kstreamlined-gradle-plugin/build.gradle.kts
@@ -85,7 +85,7 @@ detekt {
 }
 
 tasks.withType(Detekt::class.java).configureEach {
-    jvmTarget = JvmTarget.JVM_22.target
+    jvmTarget = JvmTarget.JVM_24.target
     reports {
         xml.required.set(false)
         sarif.required.set(false)

--- a/build-logic/kstreamlined-gradle-plugin/build.gradle.kts
+++ b/build-logic/kstreamlined-gradle-plugin/build.gradle.kts
@@ -81,7 +81,6 @@ detekt {
     source.from(files("src/"))
     config.from(files("$rootDir/../detekt.yml"))
     buildUponDefaultConfig = true
-    allRules = true
     parallel = true
 }
 
@@ -99,7 +98,7 @@ dependencies {
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
 
     // enable Ktlint formatting
-//    detektPlugins(libs.plugin.detektFormatting)
+    detektPlugins(libs.plugin.detektKtlintWrapper)
 
     // enable lint checks for Gradle plugins
     lintChecks(libs.androidx.lintGradle)

--- a/build-logic/kstreamlined-gradle-plugin/build.gradle.kts
+++ b/build-logic/kstreamlined-gradle-plugin/build.gradle.kts
@@ -1,5 +1,4 @@
-import io.gitlab.arturbosch.detekt.Detekt
-import org.gradle.kotlin.dsl.withType
+import dev.detekt.gradle.Detekt
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -90,7 +89,6 @@ tasks.withType(Detekt::class.java).configureEach {
     jvmTarget = JvmTarget.JVM_22.target
     reports {
         xml.required.set(false)
-        txt.required.set(false)
         sarif.required.set(false)
         md.required.set(false)
     }
@@ -101,7 +99,7 @@ dependencies {
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
 
     // enable Ktlint formatting
-    detektPlugins(libs.plugin.detektFormatting)
+//    detektPlugins(libs.plugin.detektFormatting)
 
     // enable lint checks for Gradle plugins
     lintChecks(libs.androidx.lintGradle)

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/buildEnvironment.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/buildEnvironment.kt
@@ -7,11 +7,8 @@ public val Project.isCiBuild: Boolean
 public val Project.isIdeBuild: Boolean
     get() = providers.systemProperty("idea.active").orNull == "true"
 
-public fun Project.envOrProp(name: String): Provider<String> {
-    return providers.environmentVariable(name).orElse(
-        providers.gradleProperty(name).orElse("")
-    )
-}
+public fun Project.envOrProp(name: String): Provider<String> =
+    providers.environmentVariable(name).orElse(providers.gradleProperty(name).orElse(""))
 
 internal val Project.runningPaparazzi: Boolean
     get() = gradle.startParameter.taskNames.any {

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/ComposeConventionPlugin.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/ComposeConventionPlugin.kt
@@ -20,7 +20,7 @@ internal class ComposeConventionPlugin : Plugin<Project> {
             it.targetKotlinPlatforms.set(
                 KotlinPlatformType.entries.filterNot { target ->
                     target == KotlinPlatformType.js || target == KotlinPlatformType.wasm
-                }
+                },
             )
         }
     }

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/KmpTestConventionPlugin.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/KmpTestConventionPlugin.kt
@@ -8,7 +8,6 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.powerassert.gradle.PowerAssertGradleExtension
 
 internal class KmpTestConventionPlugin : Plugin<Project> {
-
     override fun apply(target: Project): Unit = with(target) {
         with(pluginManager) {
             apply("org.jetbrains.kotlin.multiplatform")
@@ -28,7 +27,7 @@ internal class KmpTestConventionPlugin : Plugin<Project> {
                     "kotlin.test.assertTrue",
                     "kotlin.test.assertFalse",
                     "kotlin.test.assertNull",
-                )
+                ),
             )
         }
     }

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/buildlogic/AndroidSdk.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/buildlogic/AndroidSdk.kt
@@ -1,8 +1,8 @@
 package io.github.reactivecircus.kstreamlined.gradle.buildlogic
 
 internal object AndroidSdk {
-    const val minSdk = 26
-    const val targetSdk = 36
-    const val compileSdk = 36
-    const val buildTools = "36.0.0"
+    const val MinSdk = 26
+    const val TargetSdk = 36
+    const val CompileSdk = 36
+    const val BuildTools = "36.0.0"
 }

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/buildlogic/androidBuildLogic.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/buildlogic/androidBuildLogic.kt
@@ -17,10 +17,10 @@ import java.io.File
  * Apply baseline configurations on an Android Application or Library project.
  */
 internal fun CommonExtension.configureCommonAndroidExtension(project: Project) {
-    compileSdk = AndroidSdk.compileSdk
-    buildToolsVersion = AndroidSdk.buildTools
+    compileSdk = AndroidSdk.CompileSdk
+    buildToolsVersion = AndroidSdk.BuildTools
 
-    defaultConfig.minSdk = AndroidSdk.minSdk
+    defaultConfig.minSdk = AndroidSdk.MinSdk
 
     testOptions.animationsDisabled = true
 
@@ -42,9 +42,9 @@ internal fun CommonExtension.configureCommonAndroidExtension(project: Project) {
  * Apply baseline configurations on an KMP Android Library project.
  */
 internal fun KotlinMultiplatformAndroidLibraryExtension.configureKmpAndroidLibraryExtension(project: Project) {
-    compileSdk = AndroidSdk.compileSdk
-    minSdk = AndroidSdk.minSdk
-    buildToolsVersion = AndroidSdk.buildTools
+    compileSdk = AndroidSdk.CompileSdk
+    minSdk = AndroidSdk.MinSdk
+    buildToolsVersion = AndroidSdk.BuildTools
 
     withDeviceTest {
         animationsDisabled = true
@@ -64,7 +64,7 @@ internal fun KotlinMultiplatformAndroidLibraryExtension.configureKmpAndroidLibra
  */
 internal fun ApplicationExtension.configureAndroidApplicationExtension() {
     defaultConfig {
-        targetSdk = AndroidSdk.targetSdk
+        targetSdk = AndroidSdk.TargetSdk
     }
 
     androidResources {
@@ -77,12 +77,12 @@ internal fun ApplicationExtension.configureAndroidApplicationExtension() {
  * Apply baseline configurations on an Android Test project.
  */
 internal fun TestExtension.configureAndroidTestExtension() {
-    compileSdk = AndroidSdk.compileSdk
-    buildToolsVersion = AndroidSdk.buildTools
+    compileSdk = AndroidSdk.CompileSdk
+    buildToolsVersion = AndroidSdk.BuildTools
 
     defaultConfig {
-        minSdk = AndroidSdk.minSdk
-        targetSdk = AndroidSdk.targetSdk
+        minSdk = AndroidSdk.MinSdk
+        targetSdk = AndroidSdk.TargetSdk
     }
 
     compileOptions {
@@ -129,7 +129,7 @@ private fun Packaging.configurePackagingOptions() {
             listOf(
                 "META-INF/AL2.0",
                 "META-INF/LGPL2.1",
-            )
+            ),
         )
     }
 }

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/buildlogic/detektBuildLogic.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/buildlogic/detektBuildLogic.kt
@@ -1,8 +1,8 @@
 package io.github.reactivecircus.kstreamlined.gradle.buildlogic
 
-import io.gitlab.arturbosch.detekt.Detekt
-import io.gitlab.arturbosch.detekt.DetektPlugin
-import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import dev.detekt.gradle.Detekt
+import dev.detekt.gradle.extensions.DetektExtension
+import dev.detekt.gradle.plugin.DetektPlugin
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
@@ -14,21 +14,20 @@ internal fun Project.configureDetekt() {
     pluginManager.apply(DetektPlugin::class.java)
 
     // enable Ktlint formatting
-    dependencies.add("detektPlugins", libs.plugin.detektFormatting)
+//    dependencies.add("detektPlugins", the<LibrariesForLibs>().plugin.detektFormatting)
 
     plugins.withType(DetektPlugin::class.java).configureEach {
         extensions.configure(DetektExtension::class.java) {
             it.source.from(files("src/"))
             it.config.from(files("${project.rootDir}/detekt.yml"))
-            it.buildUponDefaultConfig = true
-            it.allRules = true
-            it.parallel = true
+            it.buildUponDefaultConfig.set(true)
+            it.allRules.set(true)
+            it.parallel.set(true)
         }
         tasks.withType(Detekt::class.java).configureEach {
-            it.jvmTarget = JvmTarget.JVM_17.target
+            it.jvmTarget.set(JvmTarget.JVM_17.target)
             it.reports { report ->
                 report.xml.required.set(false)
-                report.txt.required.set(false)
                 report.sarif.required.set(false)
                 report.md.required.set(false)
             }

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/buildlogic/detektBuildLogic.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/buildlogic/detektBuildLogic.kt
@@ -21,7 +21,6 @@ internal fun Project.configureDetekt() {
             it.source.from(files("src/"))
             it.config.from(files("${project.rootDir}/detekt.yml"))
             it.buildUponDefaultConfig.set(true)
-//            it.allRules.set(true)
             it.parallel.set(true)
         }
         tasks.withType(Detekt::class.java).configureEach {

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/buildlogic/detektBuildLogic.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/buildlogic/detektBuildLogic.kt
@@ -14,14 +14,14 @@ internal fun Project.configureDetekt() {
     pluginManager.apply(DetektPlugin::class.java)
 
     // enable Ktlint formatting
-//    dependencies.add("detektPlugins", the<LibrariesForLibs>().plugin.detektFormatting)
+    dependencies.add("detektPlugins", libs.plugin.detektKtlintWrapper)
 
     plugins.withType(DetektPlugin::class.java).configureEach {
         extensions.configure(DetektExtension::class.java) {
             it.source.from(files("src/"))
             it.config.from(files("${project.rootDir}/detekt.yml"))
             it.buildUponDefaultConfig.set(true)
-            it.allRules.set(true)
+//            it.allRules.set(true)
             it.parallel.set(true)
         }
         tasks.withType(Detekt::class.java).configureEach {

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/buildlogic/kmpBuildLogic.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/buildlogic/kmpBuildLogic.kt
@@ -35,19 +35,14 @@ internal fun KotlinMultiplatformExtension.configureKmpTargets(
 internal enum class KmpModuleType {
     JvmAndIos,
     AndroidAndIos,
-    IosOnly;
+    IosOnly,
+    ;
 
-    fun jvmTargetEnabled(): Boolean {
-        return this == JvmAndIos
-    }
+    fun jvmTargetEnabled(): Boolean = this == JvmAndIos
 
-    fun androidTargetEnabled(): Boolean {
-        return this == AndroidAndIos
-    }
+    fun androidTargetEnabled(): Boolean = this == AndroidAndIos
 
-    fun iosTargetEnabled(): Boolean {
-        return this == JvmAndIos || this == AndroidAndIos || this == IosOnly
-    }
+    fun iosTargetEnabled(): Boolean = this == JvmAndIos || this == AndroidAndIos || this == IosOnly
 }
 
 /**

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/variantUtils.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/variantUtils.kt
@@ -13,15 +13,13 @@ public fun <T : Serializable> Variant.addBuildConfigField(key: String, value: T)
     buildConfigFields?.put(key, buildConfigField)
 }
 
-public fun Project.shouldEnableVariant(variantName: String): Boolean {
-    return variantName in listOf(
-        "devDebug",
-        "demoDebug",
-        "mockDebug",
-        "prodRelease",
-    ) ||
-        // nonMinified variant for baseline profile generation
-        isGeneratingBaselineProfile && variantName == "devNonMinifiedRelease" ||
-        // benchmark variants
-        isRunningBenchmark && variantName in listOf("devRelease", "devBenchmarkRelease")
-}
+public fun Project.shouldEnableVariant(variantName: String): Boolean = variantName in listOf(
+    "devDebug",
+    "demoDebug",
+    "mockDebug",
+    "prodRelease",
+) ||
+    // nonMinified variant for baseline profile generation
+    isGeneratingBaselineProfile && variantName == "devNonMinifiedRelease" ||
+    // benchmark variants
+    isRunningBenchmark && variantName in listOf("devRelease", "devBenchmarkRelease")

--- a/detekt.yml
+++ b/detekt.yml
@@ -1,14 +1,7 @@
-comments:
-  active: false
-
 complexity:
-  LabeledExpression:
-    active: false
   LongMethod:
     active: false
   LongParameterList:
-    active: false
-  StringLiteralDuplication:
     active: false
   TooManyFunctions:
     allowedFunctionsPerFile: 20
@@ -26,8 +19,6 @@ ktlint:
     active: false
   FunctionSignature:
     active: false
-#  IfElseWrapping:
-#    active: false
   MaximumLineLength:
     active: false
   MultilineExpressionWrapping:

--- a/detekt.yml
+++ b/detekt.yml
@@ -1,16 +1,41 @@
+comments:
+  active: false
+
 complexity:
+  LabeledExpression:
+    active: false
   LongMethod:
     active: false
   LongParameterList:
     active: false
+  StringLiteralDuplication:
+    active: false
   TooManyFunctions:
-    thresholdInFiles: 20
+    allowedFunctionsPerFile: 20
 
-formatting:
+ktlint:
+  ClassSignature:
+    active: false
+  ChainMethodContinuation:
+    active: false
+  BackingPropertyNaming:
+    active: false
   Filename:
     active: false
+  FunctionExpressionBody:
+    active: false
+  FunctionSignature:
+    active: false
+#  IfElseWrapping:
+#    active: false
   MaximumLineLength:
     active: false
+  MultilineExpressionWrapping:
+    active: false
+  StringTemplateIndent:
+    active: false
+  PropertyName:
+    constantNamingStyle: 'pascal_case'
 
 naming:
   FunctionNaming:
@@ -26,7 +51,7 @@ style:
     ignorePropertyDeclaration: true
   MaxLineLength:
     excludes: ['**/test/**', '**/*Test/**']
-  UnusedPrivateMember:
+  UnusedPrivateFunction:
     ignoreAnnotated:
       - Preview
       - PreviewLightDark

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -79,7 +79,7 @@ plugin-crashlytics = { module = "com.google.firebase:firebase-crashlytics-gradle
 plugin-firebasePerf = { module = "com.google.firebase:perf-plugin", version.ref = "firebase-perfPlugin"}
 plugin-appDistribution = { module = "com.google.firebase:firebase-appdistribution-gradle", version.ref = "firebase-appDistributionPlugin"}
 plugin-detekt = { module = "dev.detekt:detekt-gradle-plugin", version.ref = "detekt"}
-plugin-detektFormatting = { module = "dev.detekt:detekt-formatting", version.ref = "detekt"}
+plugin-detektKtlintWrapper = { module = "dev.detekt:detekt-rules-ktlint-wrapper", version.ref = "detekt"}
 plugin-playPublisher = { module = "com.github.triplet.gradle:play-publisher", version.ref = "playPublisher"}
 plugin-skie = { module = "co.touchlab.skie:co.touchlab.skie.gradle.plugin", version.ref = "skie"}
 plugin-sqldelight = { module = "app.cash.sqldelight:app.cash.sqldelight.gradle.plugin", version.ref = "sqldelight"}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ apollo-adapters = "0.7.0"
 apollo-mockserver = "0.2.0"
 googleServices = "4.4.3"
 invert = "0.0.4-dev"
-detekt = "1.23.8"
+detekt = "2.0.0-alpha.0"
 playPublisher = "3.12.1"
 skie = "0.10.6"
 leakcanary = "2.14"
@@ -78,8 +78,8 @@ plugin-googleServices = { module = "com.google.gms:google-services", version.ref
 plugin-crashlytics = { module = "com.google.firebase:firebase-crashlytics-gradle", version.ref = "firebase-crashlyticsPlugin"}
 plugin-firebasePerf = { module = "com.google.firebase:perf-plugin", version.ref = "firebase-perfPlugin"}
 plugin-appDistribution = { module = "com.google.firebase:firebase-appdistribution-gradle", version.ref = "firebase-appDistributionPlugin"}
-plugin-detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt"}
-plugin-detektFormatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt"}
+plugin-detekt = { module = "dev.detekt:detekt-gradle-plugin", version.ref = "detekt"}
+plugin-detektFormatting = { module = "dev.detekt:detekt-formatting", version.ref = "detekt"}
 plugin-playPublisher = { module = "com.github.triplet.gradle:play-publisher", version.ref = "playPublisher"}
 plugin-skie = { module = "co.touchlab.skie:co.touchlab.skie.gradle.plugin", version.ref = "skie"}
 plugin-sqldelight = { module = "app.cash.sqldelight:app.cash.sqldelight.gradle.plugin", version.ref = "sqldelight"}
@@ -148,4 +148,4 @@ crashKios = { module = "co.touchlab:crashkios", version.ref = "crashKios" }
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 lint = { id = "com.android.lint", version.ref = "androidGradlePlugin" }
-detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+detekt = { id = "dev.detekt", version.ref = "detekt" }

--- a/kmp/database/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/database/adapters.kt
+++ b/kmp/database/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/database/adapters.kt
@@ -4,11 +4,7 @@ import app.cash.sqldelight.ColumnAdapter
 import kotlin.time.Instant
 
 public val InstantAdapter: ColumnAdapter<Instant, String> = object : ColumnAdapter<Instant, String> {
-    override fun decode(databaseValue: String): Instant {
-        return Instant.parse(databaseValue)
-    }
+    override fun decode(databaseValue: String): Instant = Instant.parse(databaseValue)
 
-    override fun encode(value: Instant): String {
-        return value.toString()
-    }
+    override fun encode(value: Instant): String = value.toString()
 }

--- a/kmp/feed-datasource/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/datasource/FeedDataSource.kt
+++ b/kmp/feed-datasource/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/datasource/FeedDataSource.kt
@@ -22,10 +22,10 @@ public class FeedDataSource(
     private val db: KStreamlinedDatabase,
     private val dbDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
-
     public fun streamFeedOrigins(): Flow<List<FeedOrigin>> {
         return db.feedOriginEntityQueries.allFeedOrigins()
-            .asFlow().mapToList(dbDispatcher)
+            .asFlow()
+            .mapToList(dbDispatcher)
             .distinctUntilChanged()
             .map { origins ->
                 origins.map { it.asExternalModel() }
@@ -34,7 +34,8 @@ public class FeedDataSource(
 
     public fun streamFeedItemsForSelectedOrigins(): Flow<List<FeedItem>> {
         return db.feedItemEntityQueries.feedItemsForSelectedOrigins()
-            .asFlow().mapToList(dbDispatcher)
+            .asFlow()
+            .mapToList(dbDispatcher)
             .distinctUntilChanged()
             .map { items ->
                 items.map { it.asExternalModel() }
@@ -43,7 +44,8 @@ public class FeedDataSource(
 
     public fun streamSavedFeedItems(): Flow<List<FeedItem>> {
         return db.feedItemEntityQueries.savedFeedItems()
-            .asFlow().mapToList(dbDispatcher)
+            .asFlow()
+            .mapToList(dbDispatcher)
             .distinctUntilChanged()
             .map { items ->
                 items.map { it.asExternalModel() }
@@ -52,7 +54,8 @@ public class FeedDataSource(
 
     public fun streamFeedItemById(id: String): Flow<FeedItem?> {
         return db.feedItemEntityQueries.feedItemById(id)
-            .asFlow().mapToOneOrNull(dbDispatcher)
+            .asFlow()
+            .mapToOneOrNull(dbDispatcher)
             .distinctUntilChanged()
             .map { it?.asExternalModel() }
     }
@@ -86,7 +89,7 @@ public class FeedDataSource(
                 }
                 db.feedOriginEntityQueries.updateSelection(
                     selected = false,
-                    key = feedOriginKey.name
+                    key = feedOriginKey.name,
                 )
             }
         }

--- a/kmp/feed-datasource/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/datasource/FeedDataSourceTest.kt
+++ b/kmp/feed-datasource/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/datasource/FeedDataSourceTest.kt
@@ -18,7 +18,6 @@ import kotlin.test.assertNull
 import kotlin.time.Instant
 
 class FeedDataSourceTest {
-
     private val feedService = FakeFeedService()
 
     private val db = createInMemoryDatabase()
@@ -64,9 +63,9 @@ class FeedDataSourceTest {
                         title = "Kotlin YouTube",
                         description = "The official YouTube channel of the Kotlin programming language",
                         selected = true,
-                    )
+                    ),
                 ),
-                awaitItem()
+                awaitItem(),
             )
 
             db.feedOriginEntityQueries.updateSelection(
@@ -86,9 +85,9 @@ class FeedDataSourceTest {
                         title = "Kotlin YouTube",
                         description = "The official YouTube channel of the Kotlin programming language",
                         selected = true,
-                    )
+                    ),
                 ),
-                awaitItem()
+                awaitItem(),
             )
         }
     }
@@ -373,7 +372,7 @@ class FeedDataSourceTest {
                     title = "Kotlin Blog",
                     description = "Latest news from the official Kotlin Blog",
                     selected = true,
-                )
+                ),
             ),
             db.feedOriginEntityQueries.allFeedOrigins().executeAsList(),
         )
@@ -397,7 +396,7 @@ class FeedDataSourceTest {
                     title = "Kotlin Blog",
                     description = "Latest news from the official Kotlin Blog",
                     selected = false,
-                )
+                ),
             ),
             db.feedOriginEntityQueries.allFeedOrigins().executeAsList(),
         )

--- a/kmp/feed-datasource/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/datasource/mapper/FeedItemMappersTest.kt
+++ b/kmp/feed-datasource/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/datasource/mapper/FeedItemMappersTest.kt
@@ -10,7 +10,6 @@ import kotlin.test.assertFailsWith
 import kotlin.time.Instant
 
 class FeedItemMappersTest {
-
     @Test
     fun `FeedItemEntity maps to FeedItem_KotlinBlog`() {
         val entity = FeedItemEntity(

--- a/kmp/feed-datasource/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/datasource/mapper/FeedOriginMappersTest.kt
+++ b/kmp/feed-datasource/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/datasource/mapper/FeedOriginMappersTest.kt
@@ -7,7 +7,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class FeedOriginMappersTest {
-
     @Test
     fun `FeedOriginEntity maps to FeedOrigin with KotlinBlog key`() {
         val entity = FeedOriginEntity(
@@ -20,7 +19,7 @@ class FeedOriginMappersTest {
             title = "Kotlin Blog",
             description = "Latest news from the official Kotlin Blog",
             selected = true,
-            key = FeedOrigin.Key.KotlinBlog
+            key = FeedOrigin.Key.KotlinBlog,
         )
         assertEquals(expected, entity.asExternalModel())
     }
@@ -37,7 +36,7 @@ class FeedOriginMappersTest {
             title = "Kotlin YouTube",
             description = "The official YouTube channel of the Kotlin programming language",
             selected = true,
-            key = FeedOrigin.Key.KotlinYouTubeChannel
+            key = FeedOrigin.Key.KotlinYouTubeChannel,
         )
         assertEquals(expected, entity.asExternalModel())
     }
@@ -54,7 +53,7 @@ class FeedOriginMappersTest {
             title = "Talking Kotlin",
             description = "Technical show discussing everything Kotlin, hosted by Hadi and Sebastian",
             selected = true,
-            key = FeedOrigin.Key.TalkingKotlinPodcast
+            key = FeedOrigin.Key.TalkingKotlinPodcast,
         )
         assertEquals(expected, entity.asExternalModel())
     }
@@ -71,7 +70,7 @@ class FeedOriginMappersTest {
             title = "Kotlin Weekly",
             description = "Weekly community Kotlin newsletter, hosted by Enrique",
             selected = true,
-            key = FeedOrigin.Key.KotlinWeekly
+            key = FeedOrigin.Key.KotlinWeekly,
         )
         assertEquals(expected, entity.asExternalModel())
     }

--- a/kmp/feed-datasource/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/datasource/mapper/KotlinWeeklyIssueItemMappersTest.kt
+++ b/kmp/feed-datasource/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/datasource/mapper/KotlinWeeklyIssueItemMappersTest.kt
@@ -6,7 +6,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class KotlinWeeklyIssueItemMappersTest {
-
     @Test
     fun `KotlinWeeklyIssueEntry maps to expected KotlinWeeklyIssueItem`() {
         val entry1 = KotlinWeeklyIssueEntry(

--- a/kmp/feed-sync/common/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/sync/FeedSyncEngine.kt
+++ b/kmp/feed-sync/common/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/sync/FeedSyncEngine.kt
@@ -4,11 +4,14 @@ import kotlinx.coroutines.flow.StateFlow
 
 public interface FeedSyncEngine {
     public val syncState: StateFlow<SyncState>
+
     public suspend fun sync(forceRefresh: Boolean = false)
 }
 
 public sealed interface SyncState {
     public data object Syncing : SyncState
+
     public data object Idle : SyncState
+
     public data object OutOfSync : SyncState
 }

--- a/kmp/feed-sync/runtime/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/sync/FeedSyncEngineImpl.kt
+++ b/kmp/feed-sync/runtime/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/sync/FeedSyncEngineImpl.kt
@@ -47,7 +47,9 @@ public class FeedSyncEngineImpl(
     private val manualSyncTrigger = Channel<SyncRequest>()
 
     private val dbChangeSyncTrigger = db.feedOriginEntityQueries
-        .allFeedOrigins().asFlow().mapToList(syncEngineDispatcher)
+        .allFeedOrigins()
+        .asFlow()
+        .mapToList(syncEngineDispatcher)
         .map { SyncRequest(forceRefresh = false, skipFeedSources = it.isNotEmpty()) }
 
     private val networkStateChangeSyncTrigger = networkMonitor.networkState
@@ -109,7 +111,7 @@ public class FeedSyncEngineImpl(
         } else {
             feedSources = null
             feedEntries = feedService.fetchFeedEntries(
-                filters = db.feedOriginEntityQueries.allFeedOrigins().executeAsList().asNetworkModels()
+                filters = db.feedOriginEntityQueries.allFeedOrigins().executeAsList().asNetworkModels(),
             )
         }
 

--- a/kmp/feed-sync/runtime/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/sync/SyncRequestEvaluator.kt
+++ b/kmp/feed-sync/runtime/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/sync/SyncRequestEvaluator.kt
@@ -23,9 +23,10 @@ internal class SyncRequestEvaluator(
     private fun shouldSyncFeedSources(): Boolean {
         val lastSyncTime = lastSyncMetadataQueries
             .lastSyncMetadata(SyncResourceType.FeedOrigins, "")
-            .executeAsOneOrNull()?.last_sync_time
+            .executeAsOneOrNull()
+            ?.last_sync_time
         return lastSyncTime == null ||
-            (clock.now() - lastSyncTime) > syncConfig.feedSourcesCacheMaxAge
+            clock.now() - lastSyncTime > syncConfig.feedSourcesCacheMaxAge
     }
 
     private fun shouldSyncFeedItems(): Boolean {
@@ -34,7 +35,7 @@ internal class SyncRequestEvaluator(
             .lastSyncMetadata(SyncResourceType.FeedItems, currentSyncParams)
             .executeAsOneOrNull()
         return itemsSyncMetadata == null ||
-            (clock.now() - itemsSyncMetadata.last_sync_time) > syncConfig.feedItemsCacheMaxAge
+            clock.now() - itemsSyncMetadata.last_sync_time > syncConfig.feedItemsCacheMaxAge
     }
 }
 

--- a/kmp/feed-sync/runtime/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/sync/mapper/feedItemEntityMappers.kt
+++ b/kmp/feed-sync/runtime/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/sync/mapper/feedItemEntityMappers.kt
@@ -5,7 +5,7 @@ import io.github.reactivecircus.kstreamlined.kmp.database.FeedItemEntity
 import io.github.reactivecircus.kstreamlined.kmp.remote.model.FeedEntry
 import io.github.reactivecircus.kstreamlined.kmp.remote.model.FeedSource
 
-@Suppress("CyclomaticComplexMethod")
+@Suppress("CyclomaticComplexMethod", "CognitiveComplexMethod")
 internal fun FeedEntry.toDbModel(
     currentFeedItems: List<FeedItemEntity>,
 ): FeedItemEntity {
@@ -40,22 +40,13 @@ internal fun FeedEntry.toDbModel(
             is FeedEntry.TalkingKotlin -> summary
             is FeedEntry.KotlinWeekly -> null
         },
-        issue_number = when (this) {
-            is FeedEntry.KotlinWeekly -> issueNumber.toLong()
-            else -> null
-        },
-        podcast_audio_url = when (this) {
-            is FeedEntry.TalkingKotlin -> audioUrl
-            else -> null
-        },
-        podcast_duration = when (this) {
-            is FeedEntry.TalkingKotlin -> duration
-            else -> null
-        },
-        podcast_start_position = when (this) {
-            is FeedEntry.TalkingKotlin ->
-                currentFeedItems.find { it.id == id }?.podcast_start_position
-            else -> null
+        issue_number = if (this is FeedEntry.KotlinWeekly) issueNumber.toLong() else null,
+        podcast_audio_url = if (this is FeedEntry.TalkingKotlin) audioUrl else null,
+        podcast_duration = if (this is FeedEntry.TalkingKotlin) duration else null,
+        podcast_start_position = if (this is FeedEntry.TalkingKotlin) {
+            currentFeedItems.find { it.id == id }?.podcast_start_position
+        } else {
+            null
         },
         podcast_description_format = podcastDescriptionFormat,
         podcast_description_plain_text = podcastDescriptionPlainText,

--- a/kmp/feed-sync/runtime/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/sync/mapper/feedOriginEntityMappers.kt
+++ b/kmp/feed-sync/runtime/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/sync/mapper/feedOriginEntityMappers.kt
@@ -10,7 +10,7 @@ internal fun List<FeedOriginEntity>.asNetworkModels(): List<FeedSource.Key>? {
 }
 
 internal fun FeedSource.toDbModel(
-    currentFeedOrigins: List<FeedOriginEntity>
+    currentFeedOrigins: List<FeedOriginEntity>,
 ): FeedOriginEntity {
     return FeedOriginEntity(
         key = key.name,

--- a/kmp/feed-sync/runtime/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/sync/FakeClock.kt
+++ b/kmp/feed-sync/runtime/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/sync/FakeClock.kt
@@ -5,7 +5,6 @@ import kotlin.time.Instant
 
 class FakeClock : Clock {
     var currentTime: Instant = Instant.parse("2023-12-03T03:10:54Z")
-    override fun now(): Instant {
-        return currentTime
-    }
+
+    override fun now(): Instant = currentTime
 }

--- a/kmp/feed-sync/runtime/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/sync/FeedSyncEngineImplTest.kt
+++ b/kmp/feed-sync/runtime/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/sync/FeedSyncEngineImplTest.kt
@@ -30,7 +30,6 @@ import kotlin.time.Instant
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class FeedSyncEngineImplTest {
-
     private val feedService = FakeFeedService()
 
     private val db = createInMemoryDatabase()
@@ -52,6 +51,14 @@ class FeedSyncEngineImplTest {
         syncEngineScope = testScope.backgroundScope,
         syncEngineDispatcher = testDispatcher,
         clock = fakeClock,
+    )
+
+    private val newFeedEntry = FeedEntry.KotlinWeekly(
+        id = "https://mailchi.mp/kotlinweekly/kotlin-weekly-400",
+        title = "Kotlin Weekly #400",
+        publishTime = Instant.parse("2024-01-01T09:13:00Z"),
+        contentUrl = "https://mailchi.mp/kotlinweekly/kotlin-weekly-400",
+        issueNumber = 400,
     )
 
     @Test
@@ -163,7 +170,7 @@ class FeedSyncEngineImplTest {
             assertFeedItemsInDb(
                 initialFeedItems - initialFeedItems.first {
                     it.feed_origin_key == FeedSource.Key.KotlinBlog.name
-                } + newFeedEntry.toDbModel(emptyList())
+                } + newFeedEntry.toDbModel(emptyList()),
             )
         }
     }
@@ -449,14 +456,6 @@ class FeedSyncEngineImplTest {
             assertFeedItemsInDb(emptyList())
         }
     }
-
-    private val newFeedEntry = FeedEntry.KotlinWeekly(
-        id = "https://mailchi.mp/kotlinweekly/kotlin-weekly-400",
-        title = "Kotlin Weekly #400",
-        publishTime = Instant.parse("2024-01-01T09:13:00Z"),
-        contentUrl = "https://mailchi.mp/kotlinweekly/kotlin-weekly-400",
-        issueNumber = 400,
-    )
 
     private fun assertFeedOriginsInDb(expected: List<FeedOriginEntity>) {
         val savedFeedOrigins = db.feedOriginEntityQueries.allFeedOrigins().executeAsList()

--- a/kmp/feed-sync/runtime/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/sync/SyncRequestEvaluatorTest.kt
+++ b/kmp/feed-sync/runtime/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/sync/SyncRequestEvaluatorTest.kt
@@ -9,7 +9,6 @@ import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
 class SyncRequestEvaluatorTest {
-
     private val db = createInMemoryDatabase()
 
     private val syncConfig = SyncConfig.Default

--- a/kmp/feed-sync/runtime/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/sync/mapper/FeedItemEntityMappersTest.kt
+++ b/kmp/feed-sync/runtime/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/sync/mapper/FeedItemEntityMappersTest.kt
@@ -9,7 +9,6 @@ import kotlin.test.assertEquals
 import kotlin.time.Instant
 
 class FeedItemEntityMappersTest {
-
     @Test
     fun `FeedEntry_KotlinBlog maps to expected db model`() {
         val feedEntry = FeedEntry.KotlinBlog(

--- a/kmp/feed-sync/runtime/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/sync/mapper/FeedOriginEntityMappersTest.kt
+++ b/kmp/feed-sync/runtime/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/sync/mapper/FeedOriginEntityMappersTest.kt
@@ -7,7 +7,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 class FeedOriginEntityMappersTest {
-
     @Test
     fun `list of FeedOriginEntity maps to expected network models when selected feed origins exist`() {
         val feedOriginEntities = listOf(
@@ -28,7 +27,7 @@ class FeedOriginEntityMappersTest {
                 title = "title3",
                 description = "description3",
                 selected = true,
-            )
+            ),
         )
         val expected = listOf(
             FeedSource.Key.KotlinBlog,
@@ -114,7 +113,7 @@ class FeedOriginEntityMappersTest {
                 title = "title3",
                 description = "description3",
                 selected = true,
-            )
+            ),
         )
         val expected = "KotlinBlog,TalkingKotlinPodcast"
         assertEquals(expected, feedOriginEntities.toSyncParams())

--- a/kmp/feed-sync/runtime/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/sync/mapper/HtmlContentParserTest.kt
+++ b/kmp/feed-sync/runtime/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/sync/mapper/HtmlContentParserTest.kt
@@ -5,7 +5,6 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 class HtmlContentParserTest {
-
     @Test
     fun `tryParseHtml returns null for non-HTML content`() {
         assertNull(tryParseHtml("This is plain text"))
@@ -24,8 +23,8 @@ class HtmlContentParserTest {
                         <li>First item</li>
                         <li>Second item with <b>bold</b> text</li>
                     </ul>
-                """.trimIndent()
-            )
+                """.trimIndent(),
+            ),
         )
         assertNotNull(tryParseHtml("<p>This is &quot;quoted&quot; text with &amp; ampersand</p>"))
         assertNotNull(tryParseHtml("Plain text followed by <p>HTML</p>"))
@@ -37,8 +36,8 @@ class HtmlContentParserTest {
                     <ul>
                         <li>With a list</li>
                     </ul>
-                """.trimIndent()
-            )
+                """.trimIndent(),
+            ),
         )
     }
 }

--- a/kmp/feed-sync/testing/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/sync/FakeFeedSyncEngine.kt
+++ b/kmp/feed-sync/testing/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/sync/FakeFeedSyncEngine.kt
@@ -5,21 +5,20 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 public class FakeFeedSyncEngine : FeedSyncEngine {
-
     public val recordedSyncs: Turbine<RecordedSync> = Turbine()
+
+    override val syncState: StateFlow<SyncState>
+        field = MutableStateFlow<SyncState>(SyncState.Idle)
 
     public fun emitSyncState(newState: SyncState) {
         syncState.value = newState
     }
-
-    override val syncState: StateFlow<SyncState>
-        field = MutableStateFlow<SyncState>(SyncState.Idle)
 
     override suspend fun sync(forceRefresh: Boolean) {
         recordedSyncs.add(RecordedSync(forceRefresh))
     }
 
     public data class RecordedSync(
-        val forceRefresh: Boolean
+        val forceRefresh: Boolean,
     )
 }

--- a/kmp/feed-sync/testing/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/sync/FakeFeedSyncEngineTest.kt
+++ b/kmp/feed-sync/testing/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/feed/sync/FakeFeedSyncEngineTest.kt
@@ -6,7 +6,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class FakeFeedSyncEngineTest {
-
     private val fakeFeedSyncEngine = FakeFeedSyncEngine()
 
     @Test

--- a/kmp/network-monitor/runtime/src/iosMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/networkmonitor/AppleNetworkMonitor.kt
+++ b/kmp/network-monitor/runtime/src/iosMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/networkmonitor/AppleNetworkMonitor.kt
@@ -27,7 +27,7 @@ public class AppleNetworkMonitor(
                     NetworkState.Connected
                 } else {
                     NetworkState.Disconnected
-                }
+                },
             )
         }
         nw_path_monitor_set_queue(monitor, dispatch_queue_create("NWPathMonitor", null))

--- a/kmp/network-monitor/testing/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/networkmonitor/FakeNetworkMonitor.kt
+++ b/kmp/network-monitor/testing/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/networkmonitor/FakeNetworkMonitor.kt
@@ -4,7 +4,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 public class FakeNetworkMonitor : NetworkMonitor {
-
     override val networkState: StateFlow<NetworkState>
         field = MutableStateFlow(NetworkState.Unknown)
 

--- a/kmp/network-monitor/testing/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/networkmonitor/FakeNetworkMonitorTest.kt
+++ b/kmp/network-monitor/testing/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/networkmonitor/FakeNetworkMonitorTest.kt
@@ -6,7 +6,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class FakeNetworkMonitorTest {
-
     private val fakeNetworkMonitor = FakeNetworkMonitor()
 
     @Test

--- a/kmp/presentation/content-viewer/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/contentviewer/ContentViewerUiModels.kt
+++ b/kmp/presentation/content-viewer/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/contentviewer/ContentViewerUiModels.kt
@@ -4,12 +4,16 @@ import io.github.reactivecircus.kstreamlined.kmp.model.feed.FeedItem
 
 public sealed interface ContentViewerUiState {
     public data object Initializing : ContentViewerUiState
+
     public data object NotFound : ContentViewerUiState
+
     public data class Content(val item: FeedItem) : ContentViewerUiState
 }
 
 public sealed interface ContentViewerUiEvent {
     public data class LoadContent(val id: String) : ContentViewerUiEvent
+
     public data object ToggleSavedForLater : ContentViewerUiEvent
+
     public data object Reset : ContentViewerUiEvent
 }

--- a/kmp/presentation/content-viewer/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/contentviewer/ContentViewerPresenterTest.kt
+++ b/kmp/presentation/content-viewer/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/contentviewer/ContentViewerPresenterTest.kt
@@ -17,7 +17,6 @@ import kotlin.test.assertEquals
 import kotlin.time.Instant
 
 class ContentViewerPresenterTest {
-
     private val feedService = FakeFeedService()
 
     private val db = createInMemoryDatabase()
@@ -111,14 +110,14 @@ class ContentViewerPresenterTest {
 
                 assertEquals(
                     ContentViewerUiState.Content(item.copy(savedForLater = true)),
-                    awaitItem()
+                    awaitItem(),
                 )
 
                 presenter.eventSink(ContentViewerUiEvent.ToggleSavedForLater)
 
                 assertEquals(
                     ContentViewerUiState.Content(item.copy(savedForLater = false)),
-                    awaitItem()
+                    awaitItem(),
                 )
             }
         }

--- a/kmp/presentation/home/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/home/HomeFeedItem.kt
+++ b/kmp/presentation/home/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/home/HomeFeedItem.kt
@@ -5,5 +5,6 @@ import io.github.reactivecircus.kstreamlined.kmp.model.feed.FeedItem
 
 public sealed interface HomeFeedItem {
     public data class SectionHeader(val title: String) : HomeFeedItem
+
     public data class Item(val displayableFeedItem: DisplayableFeedItem<FeedItem>) : HomeFeedItem
 }

--- a/kmp/presentation/home/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/home/HomePresenter.kt
+++ b/kmp/presentation/home/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/home/HomePresenter.kt
@@ -55,6 +55,7 @@ public class HomePresenter(
         return uiState
     }
 
+    @Suppress("CognitiveComplexMethod")
     private fun uiStateFlow(
         currentState: () -> HomeUiState,
     ): Flow<HomeUiState> = combineWithMetadata(

--- a/kmp/presentation/home/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/home/combineWithMetadata.kt
+++ b/kmp/presentation/home/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/home/combineWithMetadata.kt
@@ -11,7 +11,7 @@ internal fun <T1, T2, T3, R> combineWithMetadata(
     flow1: Flow<T1>,
     flow2: Flow<T2>,
     flow3: Flow<T3>,
-    @BuilderInference transform: suspend (T1, T2, T3, TransformMetadata) -> R
+    @BuilderInference transform: suspend (T1, T2, T3, TransformMetadata) -> R,
 ): Flow<R> = flow {
     var isFirstTransform = true
     var lastEmittedFlowIndex = -1
@@ -30,7 +30,7 @@ internal fun <T1, T2, T3, R> combineWithMetadata(
             value1,
             value2,
             value3,
-            TransformMetadata(isFirstTransform, lastEmittedFlowIndex)
+            TransformMetadata(isFirstTransform, lastEmittedFlowIndex),
         )
     }.collect {
         emit(it)

--- a/kmp/presentation/home/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/home/homeFeedItemMapper.kt
+++ b/kmp/presentation/home/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/home/homeFeedItemMapper.kt
@@ -22,7 +22,7 @@ internal fun List<FeedItem>.toHomeFeedItems(
             currentSectionHeader = sectionHeader
         }
         val displayableFeedItem = feedItem.toDisplayable(
-            feedItem.publishTime.timeAgo(clock, timeZone)
+            feedItem.publishTime.timeAgo(clock, timeZone),
         )
         homeFeedItems.add(HomeFeedItem.Item(displayableFeedItem))
     }

--- a/kmp/presentation/home/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/home/homeUiModels.kt
+++ b/kmp/presentation/home/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/home/homeUiModels.kt
@@ -17,6 +17,8 @@ public sealed interface HomeUiState {
 
 public sealed interface HomeUiEvent {
     public data class ToggleSavedForLater(val item: FeedItem) : HomeUiEvent
+
     public data object Refresh : HomeUiEvent
+
     public data object DismissTransientError : HomeUiEvent
 }

--- a/kmp/presentation/home/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/home/CombineWithMetadataTest.kt
+++ b/kmp/presentation/home/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/home/CombineWithMetadataTest.kt
@@ -8,7 +8,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class CombineWithMetadataTest {
-
     @Test
     fun `combineWithMetadata emits expected metadata`() =
         runTest {

--- a/kmp/presentation/home/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/home/HomeFeedItemMapperTest.kt
+++ b/kmp/presentation/home/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/home/HomeFeedItemMapperTest.kt
@@ -9,13 +9,10 @@ import kotlin.time.Clock
 import kotlin.time.Instant
 
 class HomeFeedItemMapperTest {
-
     @Test
     fun `transformed HomeFeedItems are grouped by weeks with expected displayable time`() {
         val fixedClock = object : Clock {
-            override fun now(): Instant {
-                return Instant.parse("2023-12-03T03:10:54Z")
-            }
+            override fun now(): Instant = Instant.parse("2023-12-03T03:10:54Z")
         }
         val timeZone = TimeZone.UTC
 
@@ -109,7 +106,7 @@ class HomeFeedItemMapperTest {
                         featuredImageUrl = "feature-image-url",
                     ),
                     displayablePublishTime = "Moments ago",
-                )
+                ),
             ),
             HomeFeedItem.Item(
                 displayableFeedItem = DisplayableFeedItem(
@@ -123,7 +120,7 @@ class HomeFeedItemMapperTest {
                         description = "description",
                     ),
                     displayablePublishTime = "30 minutes ago",
-                )
+                ),
             ),
             HomeFeedItem.Item(
                 displayableFeedItem = DisplayableFeedItem(
@@ -136,7 +133,7 @@ class HomeFeedItemMapperTest {
                         issueNumber = 1,
                     ),
                     displayablePublishTime = "5 hours ago",
-                )
+                ),
             ),
             HomeFeedItem.Item(
                 displayableFeedItem = DisplayableFeedItem(
@@ -155,7 +152,7 @@ class HomeFeedItemMapperTest {
                         startPositionMillis = 0,
                     ),
                     displayablePublishTime = "Yesterday",
-                )
+                ),
             ),
             HomeFeedItem.Item(
                 displayableFeedItem = DisplayableFeedItem(
@@ -168,7 +165,7 @@ class HomeFeedItemMapperTest {
                         featuredImageUrl = "feature-image-url",
                     ),
                     displayablePublishTime = "5 days ago",
-                )
+                ),
             ),
             HomeFeedItem.SectionHeader("Last week"),
             HomeFeedItem.Item(
@@ -183,7 +180,7 @@ class HomeFeedItemMapperTest {
                         description = "description",
                     ),
                     displayablePublishTime = "21 Nov 2023",
-                )
+                ),
             ),
             HomeFeedItem.SectionHeader("Earlier"),
             HomeFeedItem.Item(
@@ -197,7 +194,7 @@ class HomeFeedItemMapperTest {
                         issueNumber = 2,
                     ),
                     displayablePublishTime = "13 Nov 2023",
-                )
+                ),
             ),
         )
 

--- a/kmp/presentation/home/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/home/HomePresenterTest.kt
+++ b/kmp/presentation/home/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/home/HomePresenterTest.kt
@@ -28,7 +28,6 @@ import kotlin.time.Instant
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class HomePresenterTest {
-
     private val feedService = FakeFeedService()
 
     private val db = createInMemoryDatabase()
@@ -40,9 +39,7 @@ class HomePresenterTest {
     private val feedSyncEngine = FakeFeedSyncEngine()
 
     private val fixedClock = object : Clock {
-        override fun now(): Instant {
-            return Instant.parse("2023-12-03T03:10:54Z")
-        }
+        override fun now(): Instant = Instant.parse("2023-12-03T03:10:54Z")
     }
 
     private val timeZone = TimeZone.UTC
@@ -53,7 +50,7 @@ class HomePresenterTest {
             title = "Kotlin Blog",
             description = "Latest news from the official Kotlin Blog",
             selected = true,
-        )
+        ),
     )
 
     private val dummyFeedItems = listOf(
@@ -72,7 +69,7 @@ class HomePresenterTest {
             podcast_description_format = null,
             podcast_description_plain_text = null,
             saved_for_later = false,
-        )
+        ),
     )
 
     private val presenter = HomePresenter(
@@ -292,7 +289,7 @@ class HomePresenterTest {
                 )
 
                 presenter.eventSink(
-                    HomeUiEvent.ToggleSavedForLater(feedItem.copy(savedForLater = true))
+                    HomeUiEvent.ToggleSavedForLater(feedItem.copy(savedForLater = true)),
                 )
 
                 assertContentState(

--- a/kmp/presentation/kotlin-weekly-issue/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/kotlinweeklyissue/KotlinWeeklyIssuePresenter.kt
+++ b/kmp/presentation/kotlin-weekly-issue/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/kotlinweeklyissue/KotlinWeeklyIssuePresenter.kt
@@ -40,12 +40,13 @@ public class KotlinWeeklyIssuePresenter(
                             id = item.id,
                             contentUrl = item.contentUrl,
                             issueItems = issue.groupBy { it.group },
-                            savedForLater = item.savedForLater
+                            savedForLater = item.savedForLater,
                         )
                     }
                     .catch {
                         uiState = KotlinWeeklyIssueUiState.Error
-                    }.collect()
+                    }
+                    .collect()
             }
         }
         CollectEvent { event ->
@@ -54,7 +55,7 @@ public class KotlinWeeklyIssuePresenter(
                     itemId = event.id
                 }
                 is KotlinWeeklyIssueUiEvent.ToggleSavedForLater -> {
-                    val state = (uiState as? KotlinWeeklyIssueUiState.Content) ?: return@CollectEvent
+                    val state = uiState as? KotlinWeeklyIssueUiState.Content ?: return@CollectEvent
                     if (!state.savedForLater) {
                         feedDataSource.addSavedFeedItem(state.id)
                     } else {

--- a/kmp/presentation/kotlin-weekly-issue/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/kotlinweeklyissue/kotlinWeeklyIssueUiModels.kt
+++ b/kmp/presentation/kotlin-weekly-issue/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/kotlinweeklyissue/kotlinWeeklyIssueUiModels.kt
@@ -4,7 +4,9 @@ import io.github.reactivecircus.kstreamlined.kmp.model.feed.KotlinWeeklyIssueIte
 
 public sealed interface KotlinWeeklyIssueUiState {
     public data object Loading : KotlinWeeklyIssueUiState
+
     public data object Error : KotlinWeeklyIssueUiState
+
     public data class Content(
         val id: String,
         val contentUrl: String,
@@ -15,6 +17,8 @@ public sealed interface KotlinWeeklyIssueUiState {
 
 public sealed interface KotlinWeeklyIssueUiEvent {
     public data class LoadIssue(val id: String) : KotlinWeeklyIssueUiEvent
+
     public data object ToggleSavedForLater : KotlinWeeklyIssueUiEvent
+
     public data object Reset : KotlinWeeklyIssueUiEvent
 }

--- a/kmp/presentation/kotlin-weekly-issue/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/kotlinweeklyissue/KotlinWeeklyIssuePresenterTest.kt
+++ b/kmp/presentation/kotlin-weekly-issue/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/kotlinweeklyissue/KotlinWeeklyIssuePresenterTest.kt
@@ -20,7 +20,6 @@ import kotlin.test.assertEquals
 import kotlin.time.Instant
 
 class KotlinWeeklyIssuePresenterTest {
-
     private val feedService = FakeFeedService()
 
     private val db = createInMemoryDatabase()
@@ -69,7 +68,7 @@ class KotlinWeeklyIssuePresenterTest {
                 KotlinWeeklyIssueEntry.Group.Android -> KotlinWeeklyIssueItem.Group.Android
                 KotlinWeeklyIssueEntry.Group.Videos -> KotlinWeeklyIssueItem.Group.Videos
                 KotlinWeeklyIssueEntry.Group.Libraries -> KotlinWeeklyIssueItem.Group.Libraries
-            }
+            },
         )
     }
 
@@ -102,7 +101,7 @@ class KotlinWeeklyIssuePresenterTest {
                         id = item.id,
                         contentUrl = item.contentUrl,
                         issueItems = fakeKotlinWeeklyIssueItems.groupBy { it.group },
-                        savedForLater = item.savedForLater
+                        savedForLater = item.savedForLater,
                     ),
                     awaitItem(),
                 )
@@ -161,7 +160,7 @@ class KotlinWeeklyIssuePresenterTest {
                         id = item.id,
                         contentUrl = item.contentUrl,
                         issueItems = fakeKotlinWeeklyIssueItems.groupBy { it.group },
-                        savedForLater = item.savedForLater
+                        savedForLater = item.savedForLater,
                     ),
                     awaitItem(),
                 )
@@ -173,7 +172,7 @@ class KotlinWeeklyIssuePresenterTest {
                         id = item.id,
                         contentUrl = item.contentUrl,
                         issueItems = fakeKotlinWeeklyIssueItems.groupBy { it.group },
-                        savedForLater = true
+                        savedForLater = true,
                     ),
                     awaitItem(),
                 )
@@ -185,7 +184,7 @@ class KotlinWeeklyIssuePresenterTest {
                         id = item.id,
                         contentUrl = item.contentUrl,
                         issueItems = fakeKotlinWeeklyIssueItems.groupBy { it.group },
-                        savedForLater = false
+                        savedForLater = false,
                     ),
                     awaitItem(),
                 )

--- a/kmp/presentation/saved-for-later/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/savedforlater/savedForLaterItemMapper.kt
+++ b/kmp/presentation/saved-for-later/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/savedforlater/savedForLaterItemMapper.kt
@@ -11,7 +11,7 @@ internal fun List<FeedItem>.toSavedForLaterFeedItems(
 ): List<DisplayableFeedItem<FeedItem>> {
     return map {
         it.toDisplayable(
-            it.publishTime.toFormattedTime(timeZone)
+            it.publishTime.toFormattedTime(timeZone),
         )
     }
 }

--- a/kmp/presentation/saved-for-later/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/savedforlater/savedForLaterUiModels.kt
+++ b/kmp/presentation/saved-for-later/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/savedforlater/savedForLaterUiModels.kt
@@ -5,6 +5,7 @@ import io.github.reactivecircus.kstreamlined.kmp.model.feed.FeedItem
 
 public sealed interface SavedForLaterUiState {
     public data object Loading : SavedForLaterUiState
+
     public data class Content(
         val feedItems: List<DisplayableFeedItem<FeedItem>>,
     ) : SavedForLaterUiState

--- a/kmp/presentation/saved-for-later/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/savedforlater/SavedForLaterItemMapperTest.kt
+++ b/kmp/presentation/saved-for-later/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/savedforlater/SavedForLaterItemMapperTest.kt
@@ -8,7 +8,6 @@ import kotlin.test.assertEquals
 import kotlin.time.Instant
 
 class SavedForLaterItemMapperTest {
-
     @Test
     fun `transformed Displayable FeedItems have expected displayable time`() {
         val timeZone = TimeZone.UTC

--- a/kmp/presentation/saved-for-later/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/savedforlater/SavedForLaterPresenterTest.kt
+++ b/kmp/presentation/saved-for-later/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/savedforlater/SavedForLaterPresenterTest.kt
@@ -18,7 +18,6 @@ import kotlin.test.assertEquals
 import kotlin.time.Instant
 
 class SavedForLaterPresenterTest {
-
     private val feedService = FakeFeedService()
 
     private val db = createInMemoryDatabase()
@@ -81,7 +80,7 @@ class SavedForLaterPresenterTest {
 
                 assertEquals(
                     SavedForLaterUiState.Content(
-                        listOf(item).toSavedForLaterFeedItems(timeZone)
+                        listOf(item).toSavedForLaterFeedItems(timeZone),
                     ),
                     awaitItem(),
                 )
@@ -102,7 +101,7 @@ class SavedForLaterPresenterTest {
 
                 assertEquals(
                     SavedForLaterUiState.Content(
-                        listOf(item).toSavedForLaterFeedItems(timeZone)
+                        listOf(item).toSavedForLaterFeedItems(timeZone),
                     ),
                     awaitItem(),
                 )

--- a/kmp/presentation/talking-kotlin-episode/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/talkingkotlinepisode/talkingKotlinEpisodeUiModels.kt
+++ b/kmp/presentation/talking-kotlin-episode/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/talkingkotlinepisode/talkingKotlinEpisodeUiModels.kt
@@ -2,7 +2,9 @@ package io.github.reactivecircus.kstreamlined.kmp.presentation.talkingkotlinepis
 
 public sealed interface TalkingKotlinEpisodeUiState {
     public data object Initializing : TalkingKotlinEpisodeUiState
+
     public data object NotFound : TalkingKotlinEpisodeUiState
+
     public data class Content(
         val episode: TalkingKotlinEpisode,
         val isPlaying: Boolean,
@@ -11,8 +13,12 @@ public sealed interface TalkingKotlinEpisodeUiState {
 
 public sealed interface TalkingKotlinEpisodeUiEvent {
     public data class LoadEpisode(val id: String) : TalkingKotlinEpisodeUiEvent
+
     public data object ToggleSavedForLater : TalkingKotlinEpisodeUiEvent
+
     public data class SaveStartPosition(val startPositionMillis: Long) : TalkingKotlinEpisodeUiEvent
+
     public data object TogglePlayPause : TalkingKotlinEpisodeUiEvent
+
     public data object Reset : TalkingKotlinEpisodeUiEvent
 }

--- a/kmp/presentation/talking-kotlin-episode/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/talkingkotlinepisode/TalkingKotlinEpisodeMapperTest.kt
+++ b/kmp/presentation/talking-kotlin-episode/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/talkingkotlinepisode/TalkingKotlinEpisodeMapperTest.kt
@@ -7,7 +7,6 @@ import kotlin.test.assertEquals
 import kotlin.time.Instant
 
 class TalkingKotlinEpisodeMapperTest {
-
     @Test
     fun `transformed TalkingKotlinEpisode has expected displayable time`() {
         val timeZone = TimeZone.UTC

--- a/kmp/presentation/talking-kotlin-episode/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/talkingkotlinepisode/TalkingKotlinEpisodePresenterTest.kt
+++ b/kmp/presentation/talking-kotlin-episode/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/talkingkotlinepisode/TalkingKotlinEpisodePresenterTest.kt
@@ -19,7 +19,6 @@ import kotlin.test.assertEquals
 import kotlin.time.Instant
 
 class TalkingKotlinEpisodePresenterTest {
-
     private val feedService = FakeFeedService()
 
     private val db = createInMemoryDatabase()

--- a/kmp/pretty-time/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/prettytime/prettyTime.kt
+++ b/kmp/pretty-time/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/prettytime/prettyTime.kt
@@ -7,7 +7,7 @@ import kotlin.time.Instant
 
 @Suppress("MagicNumber")
 public fun Instant.weeksAgo(
-    clock: Clock = Clock.System
+    clock: Clock = Clock.System,
 ): String {
     val duration = clock.now().minus(this)
     val weekDifference = duration.inWholeDays / 7
@@ -27,18 +27,23 @@ public fun Instant.timeAgo(
     val duration = now.minus(this)
     return when {
         duration.inWholeMinutes < 1 -> "Moments ago"
+
         duration.inWholeHours < 1 -> if (duration.inWholeMinutes == 1L) {
             "${duration.inWholeMinutes} minute ago"
         } else {
             "${duration.inWholeMinutes} minutes ago"
         }
+
         duration.inWholeDays < 1 -> if (duration.inWholeHours == 1L) {
             "${duration.inWholeHours} hour ago"
         } else {
             "${duration.inWholeHours} hours ago"
         }
+
         duration.inWholeDays < 2 -> "Yesterday"
+
         duration.inWholeDays < 7 -> "${duration.inWholeDays} days ago"
+
         else -> toFormattedTime(timeZone)
     }
 }
@@ -48,17 +53,18 @@ public fun Instant.timeAgo(
  */
 @Suppress("MagicNumber")
 public fun Instant.toFormattedTime(
-    timeZone: TimeZone = TimeZone.currentSystemDefault()
+    timeZone: TimeZone = TimeZone.currentSystemDefault(),
 ): String {
     return toLocalDateTime(timeZone).let { localDateTime ->
         buildString {
             append(
-                localDateTime.day.toString().padStart(2, '0')
+                localDateTime.day.toString().padStart(2, '0'),
             )
             append(" ")
             append(
                 localDateTime.month.name.take(3)
-                    .lowercase().replaceFirstChar { it.titlecase() }
+                    .lowercase()
+                    .replaceFirstChar { it.titlecase() },
             )
             append(" ")
             append(localDateTime.year)

--- a/kmp/pretty-time/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/prettytime/PrettyTimeTest.kt
+++ b/kmp/pretty-time/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/prettytime/PrettyTimeTest.kt
@@ -11,11 +11,8 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 
 class PrettyTimeTest {
-
     private val fixedClock = object : Clock {
-        override fun now(): Instant {
-            return Instant.parse("2023-12-03T03:10:54Z")
-        }
+        override fun now(): Instant = Instant.parse("2023-12-03T03:10:54Z")
     }
 
     @Test
@@ -32,9 +29,7 @@ class PrettyTimeTest {
     @Test
     fun timeAgp() {
         val fixedClock = object : Clock {
-            override fun now(): Instant {
-                return Instant.parse("2023-12-03T03:10:54Z")
-            }
+            override fun now(): Instant = Instant.parse("2023-12-03T03:10:54Z")
         }
         val now = fixedClock.now()
         val timeZone = TimeZone.UTC

--- a/kmp/remote/cloud/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/remote/CloudFeedService.kt
+++ b/kmp/remote/cloud/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/remote/CloudFeedService.kt
@@ -16,7 +16,6 @@ import io.github.reactivecircus.kstreamlined.kmp.remote.model.FeedSource
 import io.github.reactivecircus.kstreamlined.kmp.remote.model.KotlinWeeklyIssueEntry
 
 public class CloudFeedService(private val apolloClient: ApolloClient) : FeedService {
-
     override suspend fun fetchFeedOrigins(): List<FeedSource> {
         return runCatching {
             apolloClient.query(FeedSourcesQuery())
@@ -33,8 +32,8 @@ public class CloudFeedService(private val apolloClient: ApolloClient) : FeedServ
         return runCatching {
             apolloClient.query(
                 FeedEntriesQuery(
-                    filters = Optional.presentIfNotNull(filters?.map { it.asApolloModel() })
-                )
+                    filters = Optional.presentIfNotNull(filters?.map { it.asApolloModel() }),
+                ),
             )
                 .fetchPolicy(FetchPolicy.NetworkOnly)
                 .execute()
@@ -46,13 +45,13 @@ public class CloudFeedService(private val apolloClient: ApolloClient) : FeedServ
     }
 
     override suspend fun fetchFeedEntriesAndOrigins(
-        filters: List<FeedSource.Key>?
+        filters: List<FeedSource.Key>?,
     ): Pair<List<FeedEntry>, List<FeedSource>> {
         return runCatching {
             apolloClient.query(
                 FeedEntriesWithSourcesQuery(
-                    filters = Optional.presentIfNotNull(filters?.map { it.asApolloModel() })
-                )
+                    filters = Optional.presentIfNotNull(filters?.map { it.asApolloModel() }),
+                ),
             )
                 .fetchPolicy(FetchPolicy.NetworkOnly)
                 .execute()
@@ -69,11 +68,11 @@ public class CloudFeedService(private val apolloClient: ApolloClient) : FeedServ
     }
 
     override suspend fun fetchKotlinWeeklyIssue(
-        url: String
+        url: String,
     ): List<KotlinWeeklyIssueEntry> {
         return runCatching {
             apolloClient.query(
-                KotlinWeeklyIssueQuery(url = url)
+                KotlinWeeklyIssueQuery(url = url),
             )
                 .fetchPolicy(FetchPolicy.CacheFirst)
                 .execute()

--- a/kmp/remote/cloud/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/remote/apollo/ApolloClientConfigs.kt
+++ b/kmp/remote/cloud/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/remote/apollo/ApolloClientConfigs.kt
@@ -9,8 +9,8 @@ public object ApolloClientConfigs {
     public val apolloStore: ApolloStore = ApolloStore(
         normalizedCacheFactory = MemoryCacheFactory(
             maxSizeBytes = MaxSizeBytes,
-            expireAfterMillis = CacheExpiry.toLong(DurationUnit.MILLISECONDS)
-        )
+            expireAfterMillis = CacheExpiry.toLong(DurationUnit.MILLISECONDS),
+        ),
     )
 }
 

--- a/kmp/remote/cloud/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/remote/CloudFeedServiceTest.kt
+++ b/kmp/remote/cloud/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/remote/CloudFeedServiceTest.kt
@@ -33,7 +33,6 @@ import kotlin.test.assertTrue
 import kotlin.time.Instant
 
 class CloudFeedServiceTest {
-
     private lateinit var mockServer: MockServer
 
     private lateinit var cloudFeedService: CloudFeedService
@@ -58,7 +57,7 @@ class CloudFeedServiceTest {
             buildKotlinYouTube {
                 title = "Kotlin YouTube entry"
                 publishTime = Instant.parse("2023-11-21T18:47:47Z")
-            }
+            },
         )
     }.feedEntries
 
@@ -71,7 +70,7 @@ class CloudFeedServiceTest {
             buildKotlinWeeklyIssueEntry {
                 title = "Kotlin Weekly entry 2"
                 group = KotlinWeeklyIssueEntryGroup.ARTICLES
-            }
+            },
         )
     }.kotlinWeeklyIssueEntries
 
@@ -82,7 +81,7 @@ class CloudFeedServiceTest {
             apolloClient = ApolloClient.Builder()
                 .serverUrl(mockServer.url())
                 .normalizedCache(MemoryCacheFactory())
-                .build()
+                .build(),
         )
     }
 
@@ -94,7 +93,7 @@ class CloudFeedServiceTest {
     @Test
     fun `fetchFeedOrigins returns result when network request was successful`() = runTest {
         mockServer.enqueueString(
-            FeedSourcesQuery.Data(feedSources = dummyFeedSources).toResponseJson()
+            FeedSourcesQuery.Data(feedSources = dummyFeedSources).toResponseJson(),
         )
         val actual = cloudFeedService.fetchFeedOrigins()
         assertEquals(dummyFeedSources.map { it.feedSourceItem.asExternalModel() }, actual)
@@ -112,7 +111,7 @@ class CloudFeedServiceTest {
     @Test
     fun `fetchFeedEntries returns result when network request was successful`() = runTest {
         mockServer.enqueueString(
-            FeedEntriesQuery.Data(feedEntries = dummyFeedEntries).toResponseJson()
+            FeedEntriesQuery.Data(feedEntries = dummyFeedEntries).toResponseJson(),
         )
         val actual = cloudFeedService.fetchFeedEntries(filters = null)
         assertEquals(dummyFeedEntries.map { it.feedEntryItem.asExternalModel() }, actual)
@@ -136,8 +135,8 @@ class CloudFeedServiceTest {
                 },
                 feedSources = dummyFeedSources.map {
                     FeedEntriesWithSourcesQuery.FeedSource(it.__typename, it.feedSourceItem)
-                }
-            ).toResponseJson()
+                },
+            ).toResponseJson(),
         )
         val actual = cloudFeedService.fetchFeedEntriesAndOrigins(filters = null)
         assertEquals(dummyFeedEntries.map { it.feedEntryItem.asExternalModel() }, actual.first)
@@ -157,7 +156,7 @@ class CloudFeedServiceTest {
     fun `fetchKotlinWeeklyIssue returns result when network request was successful`() = runTest {
         mockServer.enqueueString(
             KotlinWeeklyIssueQuery.Data(kotlinWeeklyIssueEntries = dummyKotlinWeeklyEntries)
-                .toResponseJson()
+                .toResponseJson(),
         )
         val actual = cloudFeedService.fetchKotlinWeeklyIssue(url = "url")
         assertEquals(dummyKotlinWeeklyEntries.map { it.asExternalModel() }, actual)
@@ -179,7 +178,7 @@ class CloudFeedServiceTest {
             // 1st request to populate cache
             mockServer.enqueueString(
                 KotlinWeeklyIssueQuery.Data(kotlinWeeklyIssueEntries = dummyKotlinWeeklyEntries)
-                    .toResponseJson()
+                    .toResponseJson(),
             )
             cloudFeedService.fetchKotlinWeeklyIssue(url = "url")
 

--- a/kmp/remote/cloud/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/remote/mapper/FeedEntryMappersTest.kt
+++ b/kmp/remote/cloud/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/remote/mapper/FeedEntryMappersTest.kt
@@ -12,7 +12,6 @@ import kotlin.test.assertEquals
 import kotlin.time.Instant
 
 class FeedEntryMappersTest {
-
     @Test
     fun `KotlinBlogFeedEntryItem maps to expected FeedEntry`() {
         val apolloFeedEntry = FeedEntriesQuery.Data {

--- a/kmp/remote/cloud/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/remote/mapper/FeedSourceMappersTest.kt
+++ b/kmp/remote/cloud/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/remote/mapper/FeedSourceMappersTest.kt
@@ -8,7 +8,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 class FeedSourceMappersTest {
-
     @Test
     fun `FeedSource_Key maps to expected FeedSourceKey`() {
         assertEquals(FeedSourceKey.KOTLIN_BLOG, FeedSource.Key.KotlinBlog.asApolloModel())

--- a/kmp/remote/cloud/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/remote/mapper/KotlinWeeklyIssueEntryMappersTest.kt
+++ b/kmp/remote/cloud/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/remote/mapper/KotlinWeeklyIssueEntryMappersTest.kt
@@ -7,7 +7,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class KotlinWeeklyIssueEntryMappersTest {
-
     @Test
     fun `KotlinWeeklyIssueQuery_KotlinWeeklyIssueEntry maps to expected KotlinWeeklyIssueEntry`() {
         val entry1 = KotlinWeeklyIssueQuery.KotlinWeeklyIssueEntry(

--- a/kmp/remote/common/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/remote/FeedService.kt
+++ b/kmp/remote/common/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/remote/FeedService.kt
@@ -5,13 +5,12 @@ import io.github.reactivecircus.kstreamlined.kmp.remote.model.FeedSource
 import io.github.reactivecircus.kstreamlined.kmp.remote.model.KotlinWeeklyIssueEntry
 
 public interface FeedService {
-
     public suspend fun fetchFeedOrigins(): List<FeedSource>
 
     public suspend fun fetchFeedEntries(filters: List<FeedSource.Key>? = null): List<FeedEntry>
 
     public suspend fun fetchFeedEntriesAndOrigins(
-        filters: List<FeedSource.Key>? = null
+        filters: List<FeedSource.Key>? = null,
     ): Pair<List<FeedEntry>, List<FeedSource>>
 
     public suspend fun fetchKotlinWeeklyIssue(url: String): List<KotlinWeeklyIssueEntry>

--- a/kmp/remote/edge/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/remote/EdgeFeedService.kt
+++ b/kmp/remote/edge/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/remote/EdgeFeedService.kt
@@ -5,7 +5,6 @@ import io.github.reactivecircus.kstreamlined.kmp.remote.model.FeedSource
 import io.github.reactivecircus.kstreamlined.kmp.remote.model.KotlinWeeklyIssueEntry
 
 public class EdgeFeedService : FeedService {
-
     override suspend fun fetchFeedOrigins(): List<FeedSource> {
         TODO()
     }
@@ -15,7 +14,7 @@ public class EdgeFeedService : FeedService {
     }
 
     override suspend fun fetchFeedEntriesAndOrigins(
-        filters: List<FeedSource.Key>?
+        filters: List<FeedSource.Key>?,
     ): Pair<List<FeedEntry>, List<FeedSource>> {
         TODO("Not yet implemented")
     }

--- a/kmp/remote/mock/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/remote/MockFeedService.kt
+++ b/kmp/remote/mock/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/remote/MockFeedService.kt
@@ -5,20 +5,15 @@ import io.github.reactivecircus.kstreamlined.kmp.remote.model.FeedSource
 import io.github.reactivecircus.kstreamlined.kmp.remote.model.KotlinWeeklyIssueEntry
 
 public class MockFeedService : FeedService {
-
-    override suspend fun fetchFeedOrigins(): List<FeedSource> {
-        return MockFeedSources
-    }
+    override suspend fun fetchFeedOrigins(): List<FeedSource> = MockFeedSources
 
     override suspend fun fetchFeedEntries(filters: List<FeedSource.Key>?): List<FeedEntry> {
         return MockFeedEntries
     }
 
     override suspend fun fetchFeedEntriesAndOrigins(
-        filters: List<FeedSource.Key>?
-    ): Pair<List<FeedEntry>, List<FeedSource>> {
-        return MockFeedEntries to MockFeedSources
-    }
+        filters: List<FeedSource.Key>?,
+    ): Pair<List<FeedEntry>, List<FeedSource>> = MockFeedEntries to MockFeedSources
 
     override suspend fun fetchKotlinWeeklyIssue(url: String): List<KotlinWeeklyIssueEntry> {
         return MockKotlinWeeklyIssueEntries

--- a/kmp/remote/testing/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/remote/FakeFeedService.kt
+++ b/kmp/remote/testing/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/remote/FakeFeedService.kt
@@ -5,25 +5,24 @@ import io.github.reactivecircus.kstreamlined.kmp.remote.model.FeedSource
 import io.github.reactivecircus.kstreamlined.kmp.remote.model.KotlinWeeklyIssueEntry
 
 public class FakeFeedService : FeedService {
-
     public var nextFeedSourcesResponse: suspend () -> List<FeedSource> = {
         FakeFeedSources
     }
 
     public var nextFeedEntriesResponse: suspend (
-        filters: List<FeedSource.Key>?
+        filters: List<FeedSource.Key>?,
     ) -> List<FeedEntry> = {
         FakeFeedEntries
     }
 
     public var nextKotlinWeeklyIssueResponse: suspend (
-        url: String
+        url: String,
     ) -> List<KotlinWeeklyIssueEntry> = {
         FakeKotlinWeeklyIssueEntries
     }
 
     public var nextFeedEntriesAndOriginsResponse: suspend (
-        filters: List<FeedSource.Key>?
+        filters: List<FeedSource.Key>?,
     ) -> Pair<List<FeedEntry>, List<FeedSource>> = {
         FakeFeedEntries to FakeFeedSources
     }
@@ -37,7 +36,7 @@ public class FakeFeedService : FeedService {
     }
 
     override suspend fun fetchFeedEntriesAndOrigins(
-        filters: List<FeedSource.Key>?
+        filters: List<FeedSource.Key>?,
     ): Pair<List<FeedEntry>, List<FeedSource>> {
         return nextFeedEntriesAndOriginsResponse(filters)
     }

--- a/kmp/remote/testing/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/remote/FakeFeedServiceTest.kt
+++ b/kmp/remote/testing/src/commonTest/kotlin/io/github/reactivecircus/kstreamlined/kmp/remote/FakeFeedServiceTest.kt
@@ -6,7 +6,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class FakeFeedServiceTest {
-
     private val fakeFeedService = FakeFeedService()
 
     @Test


### PR DESCRIPTION
https://github.com/detekt/detekt/releases/tag/v2.0.0-alpha.0

This unblocks building with JDK 25.

- update maven coordinates and package names
- update detekt configs
- fix new violations
- bump Detekt JVM target for `build-logic` to Java 24