### PR TITLE
Annotate presentation models with `androidx.compose.runtime:runtime-annotation`.

### DIFF
--- a/android/feature/home/compose_stability_config.conf
+++ b/android/feature/home/compose_stability_config.conf
@@ -1,3 +1,0 @@
-kotlin.collections.List<*>
-io.github.reactivecircus.kstreamlined.kmp.presentation.home.HomeFeedItem
-io.github.reactivecircus.kstreamlined.kmp.presentation.home.HomeUiState

--- a/android/feature/kotlin-weekly-issue/compose_stability_config.conf
+++ b/android/feature/kotlin-weekly-issue/compose_stability_config.conf
@@ -1,4 +1,0 @@
-kotlin.collections.List<*>
-kotlin.collections.Map<*,*>
-io.github.reactivecircus.kstreamlined.kmp.model.feed.KotlinWeeklyIssueItem
-io.github.reactivecircus.kstreamlined.kmp.presentation.kotlinweeklyissue.KotlinWeeklyIssueUiState

--- a/android/feature/saved-for-later/compose_stability_config.conf
+++ b/android/feature/saved-for-later/compose_stability_config.conf
@@ -1,3 +1,0 @@
-kotlin.collections.List<*>
-io.github.reactivecircus.kstreamlined.kmp.model.feed.DisplayableFeedItem<_>
-io.github.reactivecircus.kstreamlined.kmp.presentation.savedforlater.SavedForLaterUiState

--- a/android/feature/talking-kotlin-episode/compose_stability_config.conf
+++ b/android/feature/talking-kotlin-episode/compose_stability_config.conf
@@ -1,2 +1,0 @@
-io.github.reactivecircus.kstreamlined.kmp.presentation.talkingkotlinepisode.TalkingKotlinEpisode
-io.github.reactivecircus.kstreamlined.kmp.presentation.talkingkotlinepisode.TalkingKotlinEpisodeUiState

--- a/android/foundation/common-ui/feed/compose_stability_config.conf
+++ b/android/foundation/common-ui/feed/compose_stability_config.conf
@@ -1,1 +1,0 @@
-io.github.reactivecircus.kstreamlined.kmp.model.feed.DisplayableFeedItem<_>

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/ComposeConventionPlugin.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/ComposeConventionPlugin.kt
@@ -9,14 +9,16 @@ internal class ComposeConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
         pluginManager.apply("org.jetbrains.kotlin.plugin.compose")
         extensions.configure(ComposeCompilerGradlePluginExtension::class.java) {
-            val stabilityConfigFile = layout.projectDirectory.file("compose_stability_config.conf")
-            if (stabilityConfigFile.asFile.exists()) {
-                it.stabilityConfigurationFiles.add(stabilityConfigFile)
-            }
+            // add compose stability config file
+            it.stabilityConfigurationFiles.add(rootProject.layout.projectDirectory.file("stability_config.conf"))
+
+            // compose compiler metrics and reports
             if (providers.gradleProperty("enableComposeCompilerReports").orNull == "true") {
                 it.metricsDestination.set(layout.buildDirectory.dir("compose_metrics"))
                 it.reportsDestination.set(layout.buildDirectory.dir("compose_metrics"))
             }
+
+            // disable js and wasm targets
             it.targetKotlinPlatforms.set(
                 KotlinPlatformType.entries.filterNot { target ->
                     target == KotlinPlatformType.js || target == KotlinPlatformType.wasm

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/ComposeConventionPlugin.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/ComposeConventionPlugin.kt
@@ -10,7 +10,8 @@ internal class ComposeConventionPlugin : Plugin<Project> {
         pluginManager.apply("org.jetbrains.kotlin.plugin.compose")
         extensions.configure(ComposeCompilerGradlePluginExtension::class.java) {
             // add compose stability config file
-            it.stabilityConfigurationFiles.add(rootProject.layout.projectDirectory.file("stability_config.conf"))
+            @Suppress("UnstableApiUsage")
+            it.stabilityConfigurationFiles.add(isolated.rootProject.projectDirectory.file("stability_config.conf"))
 
             // compose compiler metrics and reports
             if (providers.gradleProperty("enableComposeCompilerReports").orNull == "true") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -102,6 +102,7 @@ androidx-compose-foundation = { module = "androidx.compose.foundation:foundation
 androidx-compose-materialIcons = { group = "androidx.compose.material", name = "material-icons-core", version.ref = "androidx-compose-materialIcons" }
 androidx-compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "androidx-compose-material3" }
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "androidx-compose-runtime" }
+androidx-compose-runtimeAnnotation = { module = "androidx.compose.runtime:runtime-annotation", version.ref = "androidx-compose-runtime" }
 androidx-compose-runtime-tracing = { module = "androidx.compose.runtime:runtime-tracing", version.ref = "androidx-compose-tracing" }
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-coreSplashscreen = { module = "androidx.core:core-splashscreen", version.ref = "androidx-coreSplashscreen" }

--- a/kmp/model/build.gradle.kts
+++ b/kmp/model/build.gradle.kts
@@ -1,3 +1,12 @@
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+
 plugins {
     id("kstreamlined.kmp.jvm-and-ios")
+}
+
+kotlin {
+    @OptIn(ExperimentalKotlinGradlePluginApi::class)
+    dependencies {
+        implementation(libs.androidx.compose.runtimeAnnotation)
+    }
 }

--- a/kmp/model/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/model/feed/DisplayableFeedItem.kt
+++ b/kmp/model/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/model/feed/DisplayableFeedItem.kt
@@ -1,5 +1,8 @@
 package io.github.reactivecircus.kstreamlined.kmp.model.feed
 
+import androidx.compose.runtime.Immutable
+
+@Immutable
 public data class DisplayableFeedItem<T : FeedItem>(
     val value: T,
     val displayablePublishTime: String,

--- a/kmp/model/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/model/feed/FeedItem.kt
+++ b/kmp/model/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/model/feed/FeedItem.kt
@@ -1,7 +1,9 @@
 package io.github.reactivecircus.kstreamlined.kmp.model.feed
 
+import androidx.compose.runtime.Immutable
 import kotlin.time.Instant
 
+@Immutable
 public sealed interface FeedItem {
     public val id: String
     public val title: String

--- a/kmp/model/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/model/feed/FeedOrigin.kt
+++ b/kmp/model/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/model/feed/FeedOrigin.kt
@@ -1,11 +1,15 @@
 package io.github.reactivecircus.kstreamlined.kmp.model.feed
 
+import androidx.compose.runtime.Immutable
+
+@Immutable
 public data class FeedOrigin(
     val key: Key,
     val title: String,
     val description: String,
     val selected: Boolean,
 ) {
+    @Immutable
     public enum class Key {
         KotlinBlog,
         KotlinYouTubeChannel,

--- a/kmp/model/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/model/feed/KotlinWeeklyIssueItem.kt
+++ b/kmp/model/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/model/feed/KotlinWeeklyIssueItem.kt
@@ -1,5 +1,8 @@
 package io.github.reactivecircus.kstreamlined.kmp.model.feed
 
+import androidx.compose.runtime.Immutable
+
+@Immutable
 public data class KotlinWeeklyIssueItem(
     val title: String,
     val summary: String,
@@ -7,6 +10,7 @@ public data class KotlinWeeklyIssueItem(
     val source: String,
     val group: Group,
 ) {
+    @Immutable
     public enum class Group {
         Announcements,
         Articles,

--- a/kmp/presentation/common/build.gradle.kts
+++ b/kmp/presentation/common/build.gradle.kts
@@ -11,5 +11,6 @@ kotlin {
     dependencies {
         api(libs.kotlinx.coroutines.core)
         api(libs.molecule.runtime)
+        api(libs.androidx.compose.runtimeAnnotation)
     }
 }

--- a/kmp/presentation/home/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/home/HomeFeedItem.kt
+++ b/kmp/presentation/home/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/home/HomeFeedItem.kt
@@ -1,8 +1,10 @@
 package io.github.reactivecircus.kstreamlined.kmp.presentation.home
 
+import androidx.compose.runtime.Immutable
 import io.github.reactivecircus.kstreamlined.kmp.model.feed.DisplayableFeedItem
 import io.github.reactivecircus.kstreamlined.kmp.model.feed.FeedItem
 
+@Immutable
 public sealed interface HomeFeedItem {
     public data class SectionHeader(val title: String) : HomeFeedItem
 

--- a/kmp/presentation/home/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/home/homeUiModels.kt
+++ b/kmp/presentation/home/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/home/homeUiModels.kt
@@ -1,7 +1,9 @@
 package io.github.reactivecircus.kstreamlined.kmp.presentation.home
 
+import androidx.compose.runtime.Immutable
 import io.github.reactivecircus.kstreamlined.kmp.model.feed.FeedItem
 
+@Immutable
 public sealed interface HomeUiState {
     public data object Loading : HomeUiState
 

--- a/kmp/presentation/kotlin-weekly-issue/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/kotlinweeklyissue/kotlinWeeklyIssueUiModels.kt
+++ b/kmp/presentation/kotlin-weekly-issue/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/kotlinweeklyissue/kotlinWeeklyIssueUiModels.kt
@@ -1,7 +1,9 @@
 package io.github.reactivecircus.kstreamlined.kmp.presentation.kotlinweeklyissue
 
+import androidx.compose.runtime.Immutable
 import io.github.reactivecircus.kstreamlined.kmp.model.feed.KotlinWeeklyIssueItem
 
+@Immutable
 public sealed interface KotlinWeeklyIssueUiState {
     public data object Loading : KotlinWeeklyIssueUiState
 

--- a/kmp/presentation/saved-for-later/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/savedforlater/savedForLaterUiModels.kt
+++ b/kmp/presentation/saved-for-later/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/savedforlater/savedForLaterUiModels.kt
@@ -1,8 +1,10 @@
 package io.github.reactivecircus.kstreamlined.kmp.presentation.savedforlater
 
+import androidx.compose.runtime.Immutable
 import io.github.reactivecircus.kstreamlined.kmp.model.feed.DisplayableFeedItem
 import io.github.reactivecircus.kstreamlined.kmp.model.feed.FeedItem
 
+@Immutable
 public sealed interface SavedForLaterUiState {
     public data object Loading : SavedForLaterUiState
 

--- a/kmp/presentation/talking-kotlin-episode/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/talkingkotlinepisode/TalkingKotlinEpisode.kt
+++ b/kmp/presentation/talking-kotlin-episode/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/talkingkotlinepisode/TalkingKotlinEpisode.kt
@@ -1,5 +1,8 @@
 package io.github.reactivecircus.kstreamlined.kmp.presentation.talkingkotlinepisode
 
+import androidx.compose.runtime.Immutable
+
+@Immutable
 public data class TalkingKotlinEpisode(
     val id: String,
     val title: String,

--- a/kmp/presentation/talking-kotlin-episode/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/talkingkotlinepisode/talkingKotlinEpisodeUiModels.kt
+++ b/kmp/presentation/talking-kotlin-episode/src/commonMain/kotlin/io/github/reactivecircus/kstreamlined/kmp/presentation/talkingkotlinepisode/talkingKotlinEpisodeUiModels.kt
@@ -1,5 +1,8 @@
 package io.github.reactivecircus.kstreamlined.kmp.presentation.talkingkotlinepisode
 
+import androidx.compose.runtime.Immutable
+
+@Immutable
 public sealed interface TalkingKotlinEpisodeUiState {
     public data object Initializing : TalkingKotlinEpisodeUiState
 

--- a/stability_config.conf
+++ b/stability_config.conf
@@ -1,0 +1,2 @@
+kotlin.collections.List<*>
+kotlin.collections.Map<*,*>


### PR DESCRIPTION
- Annotate KMP presentation models with `@Immutable` from `androidx.compose.runtime:runtime-annotation`.
- Remove per-module stability config files.
- Add single stability config file for 3rd party classes that are considered stable.