### PR TITLE
Separate langauge settings config for built-in Kotlin.

### DIFF
--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/AndroidApplicationConventionPlugin.kt
@@ -4,13 +4,13 @@ import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureAndroidApplicationExtension
 import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureAndroidApplicationVariants
+import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureBuiltInKotlin
 import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureCommonAndroidExtension
 import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureDetekt
-import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureKotlin
 import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureTest
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinBaseExtension
 
 internal class AndroidApplicationConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
@@ -18,8 +18,8 @@ internal class AndroidApplicationConventionPlugin : Plugin<Project> {
             apply("com.android.application")
         }
 
-        extensions.configure(KotlinAndroidProjectExtension::class.java) {
-            it.configureKotlin(target, enableExplicitApi = false)
+        extensions.configure(KotlinBaseExtension::class.java) {
+            it.configureBuiltInKotlin(target, enableExplicitApi = false)
         }
 
         extensions.configure(ApplicationExtension::class.java) {

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/AndroidLibraryConventionPlugin.kt
@@ -3,13 +3,13 @@ package io.github.reactivecircus.kstreamlined.gradle
 import com.android.build.api.dsl.LibraryExtension
 import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureAndroidLibraryVariants
+import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureBuiltInKotlin
 import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureCommonAndroidExtension
 import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureDetekt
-import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureKotlin
 import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureTest
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinBaseExtension
 
 internal class AndroidLibraryConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
@@ -17,8 +17,8 @@ internal class AndroidLibraryConventionPlugin : Plugin<Project> {
             apply("com.android.library")
         }
 
-        extensions.configure(KotlinAndroidProjectExtension::class.java) {
-            it.configureKotlin(target)
+        extensions.configure(KotlinBaseExtension::class.java) {
+            it.configureBuiltInKotlin(target)
         }
 
         extensions.configure(LibraryExtension::class.java) {

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/AndroidTestConventionPlugin.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/AndroidTestConventionPlugin.kt
@@ -2,11 +2,11 @@ package io.github.reactivecircus.kstreamlined.gradle
 
 import com.android.build.api.dsl.TestExtension
 import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureAndroidTestExtension
+import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureBuiltInKotlin
 import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureDetekt
-import io.github.reactivecircus.kstreamlined.gradle.buildlogic.configureKotlin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinBaseExtension
 
 internal class AndroidTestConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
@@ -14,8 +14,8 @@ internal class AndroidTestConventionPlugin : Plugin<Project> {
             apply("com.android.test")
         }
 
-        extensions.configure(KotlinAndroidProjectExtension::class.java) {
-            it.configureKotlin(target, enableExplicitApi = false)
+        extensions.configure(KotlinBaseExtension::class.java) {
+            it.configureBuiltInKotlin(target, enableExplicitApi = false)
         }
 
         extensions.configure(TestExtension::class.java) {

--- a/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/buildlogic/kotlinBuildLogic.kt
+++ b/build-logic/kstreamlined-gradle-plugin/src/main/kotlin/io/github/reactivecircus/kstreamlined/gradle/buildlogic/kotlinBuildLogic.kt
@@ -5,14 +5,39 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.compile.JavaCompile
 import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinBaseExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 /**
- * Configure Kotlin compiler options, language settings, JVM toolchain for all projects.
+ * Configure Kotlin compiler options, language settings, JVM compatibility for the [target].
  */
 internal fun KotlinProjectExtension.configureKotlin(
+    target: Project,
+) {
+    sourceSets.configureEach {
+        it.languageSettings {
+            progressiveMode = true
+            optIn("kotlin.time.ExperimentalTime")
+            optIn("kotlin.experimental.ExperimentalObjCName")
+            enableLanguageFeature("BreakContinueInInlineLambdas")
+            enableLanguageFeature("ContextParameters")
+            enableLanguageFeature("DataClassCopyRespectsConstructorVisibility")
+            enableLanguageFeature("ExplicitBackingFields")
+            enableLanguageFeature("MultiDollarInterpolation")
+            enableLanguageFeature("NestedTypeAliases")
+            enableLanguageFeature("WhenGuards")
+        }
+    }
+    target.configureJvmCompatibility()
+    explicitApi()
+}
+
+/**
+ * Same as [configureKotlin] above but for Android Gradle Plugin's built-in Kotlin.
+ */
+internal fun KotlinBaseExtension.configureBuiltInKotlin(
     target: Project,
     enableExplicitApi: Boolean = true,
 ) {
@@ -34,17 +59,21 @@ internal fun KotlinProjectExtension.configureKotlin(
             )
         }
     }
-    target.tasks.withType(KotlinJvmCompile::class.java).configureEach {
+    target.configureJvmCompatibility()
+    if (enableExplicitApi) {
+        explicitApi()
+    }
+}
+
+private fun Project.configureJvmCompatibility() {
+    tasks.withType(KotlinJvmCompile::class.java).configureEach {
         it.compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)
             jvmDefault.set(JvmDefaultMode.NO_COMPATIBILITY)
         }
     }
-    target.tasks.withType(JavaCompile::class.java).configureEach {
+    tasks.withType(JavaCompile::class.java).configureEach {
         it.sourceCompatibility = JavaVersion.VERSION_17.toString()
         it.targetCompatibility = JavaVersion.VERSION_17.toString()
-    }
-    if (enableExplicitApi) {
-        explicitApi()
     }
 }


### PR DESCRIPTION
Move Kotlin build logic for pure Android projects to a separate function.

Previously language settings were moved from `sourceSets.languageSettings` DSL to `freeCompilerArgs` to enable built-in kotlin (see https://github.com/ReactiveCircus/kstreamlined-mobile/pull/373#discussion_r2347198323).

Language features enabled via `freeCompilerArgs` doesn't seem to be recornized in the IDE, so switching back to using `languageSettings` for all non pure Android projects (KMP, Kotlin JVM), and adding a new `configureBuiltInKotlin` function that uses `freeCompilerArgs` to enable language features.