### PR TITLE
RouteBinding - support Nav3 metadata

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -109,9 +109,9 @@ kstreamlined {
             implementation(project(":kmp:presentation:settings"))
             implementation(project(":kmp:presentation:talking-kotlin-episode"))
             implementation(project(":core:designsystem"))
+            implementation(project(":core:route-metadata"))
             implementation(project(":core:scheduled-work"))
             implementation(project(":feature:content-viewer:impl"))
-            implementation(project(":feature:feed-selection:api")) // TODO remove once migrated to route binding
             implementation(project(":feature:feed-selection:impl"))
             implementation(project(":feature:home"))
             implementation(project(":feature:kotlin-weekly-issue:impl"))

--- a/android/app/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/KSActivity.kt
+++ b/android/app/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/KSActivity.kt
@@ -32,8 +32,6 @@ import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import io.github.reactivecircus.kstreamlined.android.core.designsystem.foundation.KSTheme
-import io.github.reactivecircus.kstreamlined.android.feature.feedselection.api.FeedSelectionRoute
-import io.github.reactivecircus.kstreamlined.android.feature.feedselection.impl.FeedSelectionBottomSheet
 import io.github.reactivecircus.kstreamlined.android.navigation.BottomSheetSceneStrategy
 import io.github.reactivecircus.kstreamlined.android.navigation.rememberRetainedNavEntryDecorator
 import io.github.reactivecircus.kstreamlined.kmp.capsule.inject.LocalPresenterFactory
@@ -79,11 +77,6 @@ class KSActivity : ComponentActivity() {
                             sharedTransitionScope = this,
                             entryProvider = entryProvider {
                                 appGraph.navEntryInstallers.forEach { it.install(backStack) }
-                                entry<FeedSelectionRoute>(
-                                    metadata = BottomSheetSceneStrategy.bottomSheet(),
-                                ) {
-                                    FeedSelectionBottomSheet()
-                                }
                             },
                         )
                     }

--- a/android/app/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/navigation/BottomSheetSceneStrategy.kt
+++ b/android/app/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/navigation/BottomSheetSceneStrategy.kt
@@ -5,21 +5,20 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.rememberLifecycleOwner
 import androidx.navigation3.runtime.NavEntry
-import androidx.navigation3.runtime.NavMetadataKey
 import androidx.navigation3.runtime.get
-import androidx.navigation3.runtime.metadata
 import androidx.navigation3.scene.OverlayScene
 import androidx.navigation3.scene.Scene
 import androidx.navigation3.scene.SceneStrategy
 import androidx.navigation3.scene.SceneStrategyScope
 import io.github.reactivecircus.kstreamlined.android.core.designsystem.component.ModalBottomSheet
 import io.github.reactivecircus.kstreamlined.android.core.designsystem.component.rememberModalBottomSheetState
+import io.github.reactivecircus.kstreamlined.android.core.routemetadata.BottomSheetMetadataKey
 
 class BottomSheetSceneStrategy<T : Any> : SceneStrategy<T> {
 
     override fun SceneStrategyScope<T>.calculateScene(entries: List<NavEntry<T>>): Scene<T>? {
         val lastEntry = entries.lastOrNull() ?: return null
-        lastEntry.metadata[BottomSheetKey] ?: return null
+        lastEntry.metadata[BottomSheetMetadataKey] ?: return null
         @Suppress("UNCHECKED_CAST")
         return BottomSheetScene(
             key = lastEntry.contentKey as T,
@@ -28,14 +27,6 @@ class BottomSheetSceneStrategy<T : Any> : SceneStrategy<T> {
             entry = lastEntry,
             onBack = onBack,
         )
-    }
-
-    companion object {
-        fun bottomSheet() = metadata {
-            put(BottomSheetKey, Unit)
-        }
-
-        object BottomSheetKey : NavMetadataKey<Unit>
     }
 }
 

--- a/android/core/route-metadata/build.gradle.kts
+++ b/android/core/route-metadata/build.gradle.kts
@@ -1,0 +1,8 @@
+kstreamlined {
+    jvmLibrary {
+        dependencies {
+            implementation(libs.androidx.navigation3.runtime)
+            api(libs.routebinding.runtime)
+        }
+    }
+}

--- a/android/core/route-metadata/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/core/routemetadata/BottomSheetMetadataProvider.kt
+++ b/android/core/route-metadata/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/core/routemetadata/BottomSheetMetadataProvider.kt
@@ -1,0 +1,11 @@
+package io.github.reactivecircus.kstreamlined.android.core.routemetadata
+
+import androidx.navigation3.runtime.NavMetadataKey
+import androidx.navigation3.runtime.metadata
+import io.github.reactivecircus.routebinding.runtime.RouteMetadataProvider
+
+public object BottomSheetMetadataProvider : RouteMetadataProvider {
+    override fun provide(): Map<String, Any> = metadata { put(BottomSheetMetadataKey, Unit) }
+}
+
+public data object BottomSheetMetadataKey : NavMetadataKey<Unit>

--- a/android/feature/feed-selection/impl/build.gradle.kts
+++ b/android/feature/feed-selection/impl/build.gradle.kts
@@ -5,6 +5,7 @@ kstreamlined {
 
         dependencies {
             implementation(project(":feature:feed-selection:api"))
+            implementation(project(":core:route-metadata"))
             implementation(project(":kmp:presentation:feed-selection"))
             implementation(project(":kmp:feed-model"))
         }

--- a/android/feature/feed-selection/impl/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/feature/feedselection/impl/FeedSelectionBottomSheet.kt
+++ b/android/feature/feed-selection/impl/src/main/kotlin/io/github/reactivecircus/kstreamlined/android/feature/feedselection/impl/FeedSelectionBottomSheet.kt
@@ -22,16 +22,19 @@ import androidx.tracing.trace
 import io.github.reactivecircus.kstreamlined.android.core.designsystem.component.ModalBottomSheet
 import io.github.reactivecircus.kstreamlined.android.core.designsystem.component.rememberModalBottomSheetState
 import io.github.reactivecircus.kstreamlined.android.core.designsystem.preview.PreviewKStreamlined
+import io.github.reactivecircus.kstreamlined.android.core.routemetadata.BottomSheetMetadataProvider
+import io.github.reactivecircus.kstreamlined.android.feature.feedselection.api.FeedSelectionRoute
 import io.github.reactivecircus.kstreamlined.android.feature.feedselection.impl.component.FeedOriginCard
 import io.github.reactivecircus.kstreamlined.kmp.capsule.inject.retainPresenter
 import io.github.reactivecircus.kstreamlined.kmp.feed.model.FeedOrigin
 import io.github.reactivecircus.kstreamlined.kmp.presentation.feedselection.FeedSelectionPresenter
 import io.github.reactivecircus.kstreamlined.kmp.presentation.feedselection.FeedSelectionUiEvent
 import io.github.reactivecircus.kstreamlined.kmp.presentation.feedselection.FeedSelectionUiState
+import io.github.reactivecircus.routebinding.runtime.RouteBinding
 
-// TODO revert to internal once RouteBinding supports metadata
+@RouteBinding(FeedSelectionRoute::class, BottomSheetMetadataProvider::class)
 @Composable
-public fun FeedSelectionBottomSheet(): Unit = trace("Screen:FeedSelection") {
+internal fun FeedSelectionBottomSheet(): Unit = trace("Screen:FeedSelection") {
     val presenter = retainPresenter<FeedSelectionPresenter>()
     val uiState by presenter.states.collectAsState()
     val eventSink = presenter.eventSink

--- a/build-logic/routebinding/README.md
+++ b/build-logic/routebinding/README.md
@@ -82,7 +82,57 @@ Supported optional parameter types:
 - A subtype of `NavKey` — the route for this screen (must match the `val route: KClass<out NavKey>` type in the `@RouteBinding` declaration)
 - Any parameter with a default value is also allowed
 
-### 2. Collect installers via Metro
+### 2. Optional - configure provider for Nav3 metadata
+
+RouteBinding supports the Nav3 entry metadata via the `metadataProvider` parameter of the `@RouteBinding` annotation.
+
+First provide an implementation of the `RouteMetadataProvider` interface as an `object` in a module that can be accessed from the feature modules:
+
+```kt
+object BottomSheetMetadataProvider : RouteMetadataProvider {
+    override fun provide(): Map<String, Any> = metadata { put(BottomSheetMetadataKey, Unit) }
+}
+
+data object BottomSheetMetadataKey : NavMetadataKey<Unit>
+```
+
+This module needs to depend on the runtime library explicitly, if it doesn't (need to) apply the RouteBinding Gradle plugin:
+
+```kt
+dependencies {
+    implementation("io.github.reactivecircus.routebinding:routebinding-runtime")
+}
+```
+
+Then reference the provider object from the `@RouteBinding` annotation:
+
+```kt
+@RouteBinding(SettingsRoute::class, metadataProvider = BottomSheetMetadataProvider::class)
+@Composable
+internal fun SettingsBottomSheet() { ... }
+```
+
+The generated `NavEntryInstaller` will pass the metadata to Nav3's `entry` function:
+
+```kt
+entryProviderScope.entry<FeedSelectionRoute>(metadata = BottomSheetMetadataProvider.provide()) {
+    FeedSelectionBottomSheet()
+}
+```
+
+Finally the metadata key (`BottomSheetMetadataKey` above) used by the `RouteMetadataProvider` can be used when implementing any custom Nav3 `SceneStrategy`:
+
+```kt
+class BottomSheetSceneStrategy<T : Any> : SceneStrategy<T> {
+    override fun SceneStrategyScope<T>.calculateScene(entries: List<NavEntry<T>>): Scene<T>? {
+        val lastEntry = entries.lastOrNull() ?: return null
+        lastEntry.metadata[BottomSheetMetadataKey] ?: return null
+        ...
+    }
+}
+```
+
+### 3. Collect installers via Metro
 
 In the app module, expose the contributed set of `NavEntryInstaller` from the dependency graph:
 
@@ -93,7 +143,7 @@ interface AppGraph {
 }
 ```
 
-### 3. Install entries with Nav3
+### 4. Install entries with Nav3
 
 Use the collected installers to wire up the navigation graph using Nav3's `entryProvider`:
 

--- a/build-logic/routebinding/routebinding-compiler-plugin/src/main/kotlin/io/github/reactivecircus/routebinding/compiler/ClassIds.kt
+++ b/build-logic/routebinding/routebinding-compiler-plugin/src/main/kotlin/io/github/reactivecircus/routebinding/compiler/ClassIds.kt
@@ -6,6 +6,12 @@ internal object ClassIds {
     object RouteBinding {
         val Annotation = ClassId.fromString("io/github/reactivecircus/routebinding/runtime/RouteBinding")
         val NavEntryInstaller = ClassId.fromString("io/github/reactivecircus/routebinding/runtime/NavEntryInstaller")
+        val RouteMetadataProvider = ClassId.fromString(
+            "io/github/reactivecircus/routebinding/runtime/RouteMetadataProvider",
+        )
+        val EmptyMetadataProvider = ClassId.fromString(
+            "io/github/reactivecircus/routebinding/runtime/EmptyMetadataProvider",
+        )
     }
 
     object Compose {

--- a/build-logic/routebinding/routebinding-compiler-plugin/src/main/kotlin/io/github/reactivecircus/routebinding/compiler/fir/diagnostics/RouteBindingDiagnostics.kt
+++ b/build-logic/routebinding/routebinding-compiler-plugin/src/main/kotlin/io/github/reactivecircus/routebinding/compiler/fir/diagnostics/RouteBindingDiagnostics.kt
@@ -26,6 +26,7 @@ internal object RouteBindingDiagnostics : KtDiagnosticsContainer() {
     val UNSUPPORTED_CONTEXT_PARAMETER_TYPE by error3<KtElement, String, String, String>(DEFAULT)
     val DUPLICATE_PARAMETER_TYPE by error2<KtElement, String, String>(DEFAULT)
     val ROUTE_PARAMETER_TYPE_MISMATCH by error3<KtElement, String, String, String>(DEFAULT)
+    val METADATA_PROVIDER_MUST_BE_OBJECT by error1<KtElement, String>(DEFAULT)
 
     override fun getRendererFactory(): BaseDiagnosticRendererFactory {
         return RouteBindingRendererFactory
@@ -91,6 +92,12 @@ private object RouteBindingRendererFactory : BaseDiagnosticRendererFactory() {
             "Parameter type `{2}` does not match `@RouteBinding` route type `{1}` in function `{0}`.",
             CommonRenderers.STRING,
             CommonRenderers.STRING,
+            CommonRenderers.STRING,
+        )
+        it.put(
+            RouteBindingDiagnostics.METADATA_PROVIDER_MUST_BE_OBJECT,
+            "`{0}` is not an object declaration." +
+                " `metadataProvider` must be an `object` implementing `RouteMetadataProvider'`.",
             CommonRenderers.STRING,
         )
     }

--- a/build-logic/routebinding/routebinding-compiler-plugin/src/main/kotlin/io/github/reactivecircus/routebinding/compiler/fir/diagnostics/RouteBindingFunctionChecker.kt
+++ b/build-logic/routebinding/routebinding-compiler-plugin/src/main/kotlin/io/github/reactivecircus/routebinding/compiler/fir/diagnostics/RouteBindingFunctionChecker.kt
@@ -2,6 +2,7 @@ package io.github.reactivecircus.routebinding.compiler.fir.diagnostics
 
 import io.github.reactivecircus.routebinding.compiler.ClassIds
 import org.jetbrains.kotlin.KtSourceElement
+import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.diagnostics.reportOn
@@ -12,12 +13,15 @@ import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionC
 import org.jetbrains.kotlin.fir.declarations.FirFunction
 import org.jetbrains.kotlin.fir.declarations.FirNamedFunction
 import org.jetbrains.kotlin.fir.declarations.FirValueParameter
+import org.jetbrains.kotlin.fir.declarations.findArgumentByName
 import org.jetbrains.kotlin.fir.declarations.getAnnotationByClassId
 import org.jetbrains.kotlin.fir.declarations.getKClassArgument
 import org.jetbrains.kotlin.fir.declarations.hasAnnotation
 import org.jetbrains.kotlin.fir.declarations.utils.effectiveVisibility
 import org.jetbrains.kotlin.fir.declarations.utils.nameOrSpecialName
 import org.jetbrains.kotlin.fir.resolve.getContainingClass
+import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
+import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
 import org.jetbrains.kotlin.fir.types.classId
 import org.jetbrains.kotlin.fir.types.coneType
@@ -67,6 +71,7 @@ internal object RouteBindingFunctionChecker : FirSimpleFunctionChecker(MppChecke
         }
 
         checkParameterTypes(declaration, functionName)
+        checkMetadataProvider(declaration)
     }
 
     context(context: CheckerContext, reporter: DiagnosticReporter)
@@ -197,9 +202,30 @@ internal object RouteBindingFunctionChecker : FirSimpleFunctionChecker(MppChecke
             )
         }
     }
+
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    private fun checkMetadataProvider(declaration: FirNamedFunction) {
+        val session = context.session
+        val annotation = declaration.getAnnotationByClassId(ClassIds.RouteBinding.Annotation, session) ?: return
+        val metadataProviderType = annotation.getKClassArgument(metadataProviderArgName) ?: return
+        val metadataProviderClassId = metadataProviderType.classId ?: return
+        if (metadataProviderClassId == ClassIds.RouteBinding.EmptyMetadataProvider) return
+
+        val classSymbol = session.symbolProvider.getClassLikeSymbolByClassId(metadataProviderClassId)
+            as? FirRegularClassSymbol ?: return
+        if (classSymbol.classKind != ClassKind.OBJECT) {
+            val argumentSource = annotation.findArgumentByName(metadataProviderArgName)?.source
+            reporter.reportOn(
+                argumentSource ?: declaration.source,
+                RouteBindingDiagnostics.METADATA_PROVIDER_MUST_BE_OBJECT,
+                metadataProviderClassId.shortClassName.asString(),
+            )
+        }
+    }
 }
 
 private val routeArgName = Name.identifier("route")
+private val metadataProviderArgName = Name.identifier("metadataProvider")
 
 private enum class SupportedParamType(val displayName: String) {
     SharedTransitionScope("SharedTransitionScope"),

--- a/build-logic/routebinding/routebinding-compiler-plugin/src/main/kotlin/io/github/reactivecircus/routebinding/compiler/ir/RouteBindingClassTransformer.kt
+++ b/build-logic/routebinding/routebinding-compiler-plugin/src/main/kotlin/io/github/reactivecircus/routebinding/compiler/ir/RouteBindingClassTransformer.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irCallWithSubstitutedType
 import org.jetbrains.kotlin.ir.builders.irDelegatingConstructorCall
 import org.jetbrains.kotlin.ir.builders.irGet
+import org.jetbrains.kotlin.ir.builders.irGetObject
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
 import org.jetbrains.kotlin.ir.declarations.IrFunction
@@ -87,11 +88,15 @@ internal class RouteBindingClassTransformer(
         sourceFunction: IrFunction,
         installFunction: IrFunction,
     ) {
-        val routeKClass = sourceFunction.getAnnotation(
-            ClassIds.RouteBinding.Annotation.asSingleFqName(),
-        ).arguments.first() as IrClassReference
+        val annotation = sourceFunction.getAnnotation(ClassIds.RouteBinding.Annotation.asSingleFqName())
+        val routeKClass = annotation.arguments.first() as IrClassReference
         val routeType = routeKClass.symbol.defaultType
         val entryFunction = nav3Symbols.entryFunction
+
+        val metadataProviderKClass = annotation.arguments.getOrNull(1) as? IrClassReference
+        val metadataProviderClass = metadataProviderKClass?.symbol?.owner as? IrClass
+        val hasMetadataProvider = metadataProviderClass != null &&
+            metadataProviderClass.classId != ClassIds.RouteBinding.EmptyMetadataProvider
 
         +irCallWithSubstitutedType(entryFunction, listOf(routeType)).apply {
             val entryProviderScopeParam = installFunction.parameters.first {
@@ -100,6 +105,20 @@ internal class RouteBindingClassTransformer(
             dispatchReceiver = irGet(entryProviderScopeParam)
 
             val entryFunctionParams = entryFunction.owner.parameters
+
+            // pass metadata to entry function if a metadataProvider is specified
+            if (hasMetadataProvider) {
+                val provideFunction = metadataProviderClass.functions.first {
+                    it.name == Name.identifier("provide")
+                }
+                val metadataParamIndex = entryFunctionParams.indexOfFirst {
+                    it.name == Name.identifier("metadata")
+                }
+                arguments[metadataParamIndex] = irCall(provideFunction).apply {
+                    dispatchReceiver = irGetObject(metadataProviderClass.symbol)
+                }
+            }
+
             val contentParamType = entryFunctionParams.last().type
             val lambdaFunctionType = IrTypeSubstitutor(
                 typeParameters = entryFunction.owner.typeParameters.map { it.symbol },

--- a/build-logic/routebinding/routebinding-compiler-plugin/src/test/data/additional-files/nav3.kt
+++ b/build-logic/routebinding/routebinding-compiler-plugin/src/test/data/additional-files/nav3.kt
@@ -9,6 +9,7 @@ class NavBackStack<T : NavKey>
 
 class EntryProviderScope<T : Any> {
     var recordedRouteType: KClass<*>? = null
+    val recordedMetadata: MutableMap<String, Any> = mutableMapOf()
 
     // not called by generated code
     fun <K : T> EntryProviderScope<T>.entry(
@@ -25,5 +26,6 @@ class EntryProviderScope<T : Any> {
         noinline content: @Composable (K) -> Unit,
     ) {
         recordedRouteType = K::class
+        recordedMetadata.putAll(metadata)
     }
 }

--- a/build-logic/routebinding/routebinding-compiler-plugin/src/test/data/box/MetadataProvider.kt
+++ b/build-logic/routebinding/routebinding-compiler-plugin/src/test/data/box/MetadataProvider.kt
@@ -10,9 +10,14 @@ import dev.zacsweers.metro.createGraph
 import dev.zacsweers.metro.DependencyGraph
 import io.github.reactivecircus.routebinding.runtime.NavEntryInstaller
 import io.github.reactivecircus.routebinding.runtime.RouteBinding
+import io.github.reactivecircus.routebinding.runtime.RouteMetadataProvider
 import kotlin.test.assertEquals
 
-@RouteBinding(DummyRoute::class)
+object DummyMetadataProvider : RouteMetadataProvider {
+    override fun provide(): Map<String, Any> = mapOf("key" to "value")
+}
+
+@RouteBinding(DummyRoute::class, metadataProvider = DummyMetadataProvider::class)
 @Composable
 internal fun SharedTransitionScope.TestScreen(
     backStack: NavBackStack<NavKey>,
@@ -38,6 +43,7 @@ fun box(): String {
     }
 
     assertEquals(DummyRoute::class, entryProviderScope.recordedRouteType)
+    assertEquals(mapOf<String, Any>("key" to "value"), entryProviderScope.recordedMetadata)
 
     return "OK"
 }

--- a/build-logic/routebinding/routebinding-compiler-plugin/src/test/data/diagnostic/NonObjectMetadataProvider.fir.diag.txt
+++ b/build-logic/routebinding/routebinding-compiler-plugin/src/test/data/diagnostic/NonObjectMetadataProvider.fir.diag.txt
@@ -1,0 +1,3 @@
+/NonObjectMetadataProvider.kt:(408,436): error: `ClassMetadataProvider` is not an object declaration. `metadataProvider` must be an `object` implementing `RouteMetadataProvider`.
+
+/NonObjectMetadataProvider.kt:(530,558): error: `RouteMetadataProvider` is not an object declaration. `metadataProvider` must be an `object` implementing `RouteMetadataProvider`.

--- a/build-logic/routebinding/routebinding-compiler-plugin/src/test/data/diagnostic/NonObjectMetadataProvider.kt
+++ b/build-logic/routebinding/routebinding-compiler-plugin/src/test/data/diagnostic/NonObjectMetadataProvider.kt
@@ -1,0 +1,18 @@
+import androidx.compose.runtime.Composable
+import androidx.navigation3.runtime.NavKey
+import io.github.reactivecircus.routebinding.runtime.RouteBinding
+import io.github.reactivecircus.routebinding.runtime.RouteMetadataProvider
+
+class ClassMetadataProvider : RouteMetadataProvider {
+    override fun provide(): Map<String, Any> = mapOf("key" to "value")
+}
+
+@RouteBinding(DummyRoute::class, metadataProvider = <!METADATA_PROVIDER_MUST_BE_OBJECT!>ClassMetadataProvider::class<!>)
+@Composable
+internal fun Screen1() {
+}
+
+@RouteBinding(DummyRoute::class, metadataProvider = <!METADATA_PROVIDER_MUST_BE_OBJECT!>RouteMetadataProvider::class<!>)
+@Composable
+internal fun Screen2() {
+}

--- a/build-logic/routebinding/routebinding-compiler-plugin/src/test/data/dump/WithMetadataProvider.fir.kt.txt
+++ b/build-logic/routebinding/routebinding-compiler-plugin/src/test/data/dump/WithMetadataProvider.fir.kt.txt
@@ -75,7 +75,7 @@ class FooScreen_NavEntryInstaller : NavEntryInstaller {
 
   context(<unused var>: EntryProviderScope<NavKey>, <unused var>: SharedTransitionScope)
   override fun install(backStack: NavBackStack<NavKey>) {
-    <unused var>.entry<DummyRoute>(metadata = TestMetadataProvider.provide(), content = local fun <anonymous>(it: DummyRoute) {
+    <unused var>.entry<DummyRoute>(metadata = DummyMetadataProvider.provide(), content = local fun <anonymous>(it: DummyRoute) {
       FooScreen(/* <this> = <unused var>, */ backStack = backStack, route = it)
     }
 )
@@ -85,7 +85,7 @@ class FooScreen_NavEntryInstaller : NavEntryInstaller {
 
 // FILE: WithMetadataProvider.kt
 
-object TestMetadataProvider : RouteMetadataProvider {
+object DummyMetadataProvider : RouteMetadataProvider {
   private constructor() /* primary */ {
     super/*Any*/()
     /* <init>() */
@@ -98,7 +98,7 @@ object TestMetadataProvider : RouteMetadataProvider {
 
 }
 
-@RouteBinding(route = DummyRoute::class, metadataProvider = TestMetadataProvider::class)
+@RouteBinding(route = DummyRoute::class, metadataProvider = DummyMetadataProvider::class)
 @Composable
 internal fun SharedTransitionScope.FooScreen(backStack: NavBackStack<NavKey>, route: DummyRoute) {
 }

--- a/build-logic/routebinding/routebinding-compiler-plugin/src/test/data/dump/WithMetadataProvider.fir.kt.txt
+++ b/build-logic/routebinding/routebinding-compiler-plugin/src/test/data/dump/WithMetadataProvider.fir.kt.txt
@@ -1,0 +1,116 @@
+// FILE: FooScreen_NavEntryInstaller.kt
+
+@Deprecated(message = "This synthesized declaration should not be used directly", level = DeprecationLevel.HIDDEN)
+@ContributesIntoSet(scope = AppScope::class)
+class FooScreen_NavEntryInstaller : NavEntryInstaller {
+  @Deprecated(message = "This synthesized declaration should not be used directly", level = DeprecationLevel.HIDDEN)
+  object MetroFactory : Factory<FooScreen_NavEntryInstaller> {
+    private constructor() /* primary */ {
+      super/*Any*/()
+      /* <init>() */
+
+    }
+
+    @HiddenFromObjC
+    @JvmStatic
+    @JsStatic
+    fun create(): Factory<FooScreen_NavEntryInstaller> {
+      return MetroFactory
+    }
+
+    @HiddenFromObjC
+    @JvmStatic
+    @JsStatic
+    fun newInstance(): FooScreen_NavEntryInstaller {
+      return FooScreen_NavEntryInstaller()
+    }
+
+    @HiddenFromObjC
+    override operator fun invoke(): FooScreen_NavEntryInstaller {
+      return MetroFactory.newInstance()
+    }
+
+    @ComptimeOnly
+    @HiddenFromObjC
+    fun mirrorFunction(): FooScreen_NavEntryInstaller {
+      return error(message = "Never called")
+    }
+
+  }
+
+  @Deprecated(message = "This synthesized declaration should not be used directly", level = DeprecationLevel.HIDDEN)
+  @MetroContribution(scope = AppScope::class)
+  @BindingContainer
+  @Origin(value = FooScreen_NavEntryInstaller::class)
+  @ComptimeOnly
+  interface MetroContributionToDevzacsweersmetroappScopeocf15 {
+    @Deprecated(message = "This synthesized declaration should not be used directly", level = DeprecationLevel.HIDDEN)
+    @ComptimeOnly
+    abstract class BindsMirror {
+      private constructor() /* primary */ {
+        super/*Any*/()
+        /* <init>() */
+
+      }
+
+      @Binds
+      @IntoSet
+      @CallableMetadata(callableName = "bindIntoSetAsNavEntryInstaller", propertyName = "", startOffset = -1, endOffset = -1)
+      abstract fun bindIntoSetAsNavEntryInstaller_intoset(instance: FooScreen_NavEntryInstaller): NavEntryInstaller
+
+    }
+
+    @IntoSet
+    @Binds
+    @ComptimeOnly
+    fun bindIntoSetAsNavEntryInstaller(instance: FooScreen_NavEntryInstaller): NavEntryInstaller {
+      return error(message = "Never called")
+    }
+
+  }
+
+  constructor() /* primary */ {
+    super/*Any*/()
+  }
+
+  context(<unused var>: EntryProviderScope<NavKey>, <unused var>: SharedTransitionScope)
+  override fun install(backStack: NavBackStack<NavKey>) {
+    <unused var>.entry<DummyRoute>(metadata = TestMetadataProvider.provide(), content = local fun <anonymous>(it: DummyRoute) {
+      FooScreen(/* <this> = <unused var>, */ backStack = backStack, route = it)
+    }
+)
+  }
+
+}
+
+// FILE: WithMetadataProvider.kt
+
+object TestMetadataProvider : RouteMetadataProvider {
+  private constructor() /* primary */ {
+    super/*Any*/()
+    /* <init>() */
+
+  }
+
+  override fun provide(): Map<String, Any> {
+    return mapOf<String, String>(pair = to<String, String>(/* <this> = "key", */ that = "value"))
+  }
+
+}
+
+@RouteBinding(route = DummyRoute::class, metadataProvider = TestMetadataProvider::class)
+@Composable
+internal fun SharedTransitionScope.FooScreen(backStack: NavBackStack<NavKey>, route: DummyRoute) {
+}
+
+fun box(): String {
+  return "OK"
+}
+
+// FILE: fooScreen_NavEntryInstallerAppScope.kt
+package metro.hints
+
+@Deprecated(message = "This synthesized declaration should not be used directly", level = DeprecationLevel.HIDDEN)
+fun AppScope(contributed: FooScreen_NavEntryInstaller) {
+  return error(message = "Never called")
+}

--- a/build-logic/routebinding/routebinding-compiler-plugin/src/test/data/dump/WithMetadataProvider.fir.txt
+++ b/build-logic/routebinding/routebinding-compiler-plugin/src/test/data/dump/WithMetadataProvider.fir.txt
@@ -1,0 +1,47 @@
+FILE: WithMetadataProvider.kt
+    public final object TestMetadataProvider : R|io/github/reactivecircus/routebinding/runtime/RouteMetadataProvider| {
+        private constructor(): R|TestMetadataProvider| {
+            super<R|kotlin/Any|>()
+        }
+
+        public open override fun provide(): R|kotlin/collections/Map<kotlin/String, kotlin/Any>| {
+            ^provide R|kotlin/collections/mapOf|<R|kotlin/String|, R|kotlin/String|>(String(key).R|kotlin/to|<R|kotlin/String|, R|kotlin/String|>(String(value)))
+        }
+
+    }
+    @R|io/github/reactivecircus/routebinding/runtime/RouteBinding|(route = <getClass>(Q|DummyRoute|) [evaluated = <getClass>(Q|DummyRoute|)], metadataProvider = <getClass>(Q|TestMetadataProvider|) [evaluated = <getClass>(Q|TestMetadataProvider|)]) @R|androidx/compose/runtime/Composable|() internal final fun R|androidx/compose/animation/SharedTransitionScope|.FooScreen(backStack: R|androidx/navigation3/runtime/NavBackStack<androidx/navigation3/runtime/NavKey>|, route: R|DummyRoute|): R|kotlin/Unit| {
+    }
+    public final fun box(): R|kotlin/String| {
+        ^box String(OK)
+    }
+FILE: /FooScreen_NavEntryInstaller.kt
+    @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/ContributesIntoSet|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public final class FooScreen_NavEntryInstaller : R|io/github/reactivecircus/routebinding/runtime/NavEntryInstaller| {
+        context(<unused var>: R|androidx/navigation3/runtime/EntryProviderScope<androidx/navigation3/runtime/NavKey>|, <unused var>: R|androidx/compose/animation/SharedTransitionScope|)
+        public final override fun install(backStack: R|androidx/navigation3/runtime/NavBackStack<androidx/navigation3/runtime/NavKey>|): R|kotlin/Unit|
+
+        public constructor(): R|FooScreen_NavEntryInstaller| {
+            super<R|kotlin/Any|>()
+        }
+
+        @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public final object MetroFactory : R|kotlin/Any| {
+            private constructor(): R|FooScreen_NavEntryInstaller.MetroFactory| {
+                super<R|kotlin/Any|>()
+            }
+
+        }
+
+        @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/MetroContribution|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) @R|dev/zacsweers/metro/BindingContainer|() @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|FooScreen_NavEntryInstaller|)) @R|dev/zacsweers/metro/internal/ComptimeOnly|() public abstract interface MetroContributionToDevzacsweersmetroappScopeocf15 : R|kotlin/Any| {
+            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public abstract class BindsMirror : R|kotlin/Any| {
+                private constructor(): R|FooScreen_NavEntryInstaller.MetroContributionToDevzacsweersmetroappScopeocf15.BindsMirror| {
+                    super<R|kotlin/Any|>()
+                }
+
+            }
+
+        }
+
+    }
+FILE: metro/hints/fooScreen_NavEntryInstallerAppScope.kt
+    package metro.hints
+
+    @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public final fun AppScope(contributed: R|FooScreen_NavEntryInstaller|): R|kotlin/Unit|

--- a/build-logic/routebinding/routebinding-compiler-plugin/src/test/data/dump/WithMetadataProvider.fir.txt
+++ b/build-logic/routebinding/routebinding-compiler-plugin/src/test/data/dump/WithMetadataProvider.fir.txt
@@ -1,6 +1,6 @@
 FILE: WithMetadataProvider.kt
-    public final object TestMetadataProvider : R|io/github/reactivecircus/routebinding/runtime/RouteMetadataProvider| {
-        private constructor(): R|TestMetadataProvider| {
+    public final object DummyMetadataProvider : R|io/github/reactivecircus/routebinding/runtime/RouteMetadataProvider| {
+        private constructor(): R|DummyMetadataProvider| {
             super<R|kotlin/Any|>()
         }
 
@@ -9,7 +9,7 @@ FILE: WithMetadataProvider.kt
         }
 
     }
-    @R|io/github/reactivecircus/routebinding/runtime/RouteBinding|(route = <getClass>(Q|DummyRoute|) [evaluated = <getClass>(Q|DummyRoute|)], metadataProvider = <getClass>(Q|TestMetadataProvider|) [evaluated = <getClass>(Q|TestMetadataProvider|)]) @R|androidx/compose/runtime/Composable|() internal final fun R|androidx/compose/animation/SharedTransitionScope|.FooScreen(backStack: R|androidx/navigation3/runtime/NavBackStack<androidx/navigation3/runtime/NavKey>|, route: R|DummyRoute|): R|kotlin/Unit| {
+    @R|io/github/reactivecircus/routebinding/runtime/RouteBinding|(route = <getClass>(Q|DummyRoute|) [evaluated = <getClass>(Q|DummyRoute|)], metadataProvider = <getClass>(Q|DummyMetadataProvider|) [evaluated = <getClass>(Q|DummyMetadataProvider|)]) @R|androidx/compose/runtime/Composable|() internal final fun R|androidx/compose/animation/SharedTransitionScope|.FooScreen(backStack: R|androidx/navigation3/runtime/NavBackStack<androidx/navigation3/runtime/NavKey>|, route: R|DummyRoute|): R|kotlin/Unit| {
     }
     public final fun box(): R|kotlin/String| {
         ^box String(OK)

--- a/build-logic/routebinding/routebinding-compiler-plugin/src/test/data/dump/WithMetadataProvider.kt
+++ b/build-logic/routebinding/routebinding-compiler-plugin/src/test/data/dump/WithMetadataProvider.kt
@@ -1,0 +1,22 @@
+import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.runtime.Composable
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import io.github.reactivecircus.routebinding.runtime.RouteBinding
+import io.github.reactivecircus.routebinding.runtime.RouteMetadataProvider
+
+object TestMetadataProvider : RouteMetadataProvider {
+    override fun provide(): Map<String, Any> = mapOf("key" to "value")
+}
+
+@RouteBinding(DummyRoute::class, metadataProvider = TestMetadataProvider::class)
+@Composable
+internal fun SharedTransitionScope.FooScreen(
+    backStack: NavBackStack<NavKey>,
+    route: DummyRoute,
+) {
+}
+
+fun box(): String {
+    return "OK"
+}

--- a/build-logic/routebinding/routebinding-compiler-plugin/src/test/data/dump/WithMetadataProvider.kt
+++ b/build-logic/routebinding/routebinding-compiler-plugin/src/test/data/dump/WithMetadataProvider.kt
@@ -5,11 +5,11 @@ import androidx.navigation3.runtime.NavKey
 import io.github.reactivecircus.routebinding.runtime.RouteBinding
 import io.github.reactivecircus.routebinding.runtime.RouteMetadataProvider
 
-object TestMetadataProvider : RouteMetadataProvider {
+object DummyMetadataProvider : RouteMetadataProvider {
     override fun provide(): Map<String, Any> = mapOf("key" to "value")
 }
 
-@RouteBinding(DummyRoute::class, metadataProvider = TestMetadataProvider::class)
+@RouteBinding(DummyRoute::class, metadataProvider = DummyMetadataProvider::class)
 @Composable
 internal fun SharedTransitionScope.FooScreen(
     backStack: NavBackStack<NavKey>,

--- a/build-logic/routebinding/routebinding-compiler-plugin/src/test/java/io/github/reactivecircus/routebinding/compiler/BoxTestGenerated.java
+++ b/build-logic/routebinding/routebinding-compiler-plugin/src/test/java/io/github/reactivecircus/routebinding/compiler/BoxTestGenerated.java
@@ -43,6 +43,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
   }
 
   @Test
+  @TestMetadata("MetadataProvider.kt")
+  public void testMetadataProvider() {
+    run("MetadataProvider.kt");
+  }
+
+  @Test
   @TestMetadata("MultipleBindingsInMultipleCompilations.kt")
   public void testMultipleBindingsInMultipleCompilations() {
     run("MultipleBindingsInMultipleCompilations.kt");

--- a/build-logic/routebinding/routebinding-compiler-plugin/src/test/java/io/github/reactivecircus/routebinding/compiler/DiagnosticTestGenerated.java
+++ b/build-logic/routebinding/routebinding-compiler-plugin/src/test/java/io/github/reactivecircus/routebinding/compiler/DiagnosticTestGenerated.java
@@ -37,6 +37,12 @@ public class DiagnosticTestGenerated extends AbstractDiagnosticTest {
   }
 
   @Test
+  @TestMetadata("NonObjectMetadataProvider.kt")
+  public void testNonObjectMetadataProvider() {
+    run("NonObjectMetadataProvider.kt");
+  }
+
+  @Test
   @TestMetadata("NonTopLevelFunction.kt")
   public void testNonTopLevelFunction() {
     run("NonTopLevelFunction.kt");

--- a/build-logic/routebinding/routebinding-compiler-plugin/src/test/java/io/github/reactivecircus/routebinding/compiler/DumpTestGenerated.java
+++ b/build-logic/routebinding/routebinding-compiler-plugin/src/test/java/io/github/reactivecircus/routebinding/compiler/DumpTestGenerated.java
@@ -43,6 +43,12 @@ public class DumpTestGenerated extends AbstractDumpTest {
   }
 
   @Test
+  @TestMetadata("WithMetadataProvider.kt")
+  public void testWithMetadataProvider() {
+    run("WithMetadataProvider.kt");
+  }
+
+  @Test
   @TestMetadata("WithParamWithDefaultValue.kt")
   public void testWithParamWithDefaultValue() {
     run("WithParamWithDefaultValue.kt");

--- a/build-logic/routebinding/routebinding-runtime/src/main/kotlin/io/github/reactivecircus/routebinding/runtime/RouteBinding.kt
+++ b/build-logic/routebinding/routebinding-runtime/src/main/kotlin/io/github/reactivecircus/routebinding/runtime/RouteBinding.kt
@@ -10,7 +10,12 @@ import kotlin.reflect.KClass
  * function to a [route] using Nav3's `EntryProviderScope` API, contributing it as a multibinding via Metro.
  *
  * @param route the [NavKey] this Composable function binds to.
+ * @param metadataProvider an object that implements [RouteMetadataProvider] to provide Nav3 metadata for this navigation entry.
+ *   Defaults to [EmptyMetadataProvider] which produces an empty metadata map.
  */
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.SOURCE)
-public annotation class RouteBinding(val route: KClass<out NavKey>)
+public annotation class RouteBinding(
+    val route: KClass<out NavKey>,
+    val metadataProvider: KClass<out RouteMetadataProvider> = EmptyMetadataProvider::class,
+)

--- a/build-logic/routebinding/routebinding-runtime/src/main/kotlin/io/github/reactivecircus/routebinding/runtime/RouteBinding.kt
+++ b/build-logic/routebinding/routebinding-runtime/src/main/kotlin/io/github/reactivecircus/routebinding/runtime/RouteBinding.kt
@@ -10,8 +10,9 @@ import kotlin.reflect.KClass
  * function to a [route] using Nav3's `EntryProviderScope` API, contributing it as a multibinding via Metro.
  *
  * @param route the [NavKey] this Composable function binds to.
- * @param metadataProvider reference to an object that implements [RouteMetadataProvider] to provide Nav3 metadata for this navigation entry.
- *   Defaults to [EmptyMetadataProvider] which won't be consumed in the generated [NavEntryInstaller].
+ * @param metadataProvider reference to an object that implements [RouteMetadataProvider] to
+ * provide Nav3 metadata for this navigation entry. Defaults to [EmptyMetadataProvider] which
+ * won't be consumed in the generated [NavEntryInstaller].
  */
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.SOURCE)

--- a/build-logic/routebinding/routebinding-runtime/src/main/kotlin/io/github/reactivecircus/routebinding/runtime/RouteBinding.kt
+++ b/build-logic/routebinding/routebinding-runtime/src/main/kotlin/io/github/reactivecircus/routebinding/runtime/RouteBinding.kt
@@ -6,12 +6,12 @@ import kotlin.reflect.KClass
 /**
  * Marks a `@Composable` function as a screen-level navigation entry for the given [route].
  *
- * The compiler plugin generates a `NavEntryInstaller` class that binds the annotated
+ * The compiler plugin generates a [NavEntryInstaller] class that binds the annotated
  * function to a [route] using Nav3's `EntryProviderScope` API, contributing it as a multibinding via Metro.
  *
  * @param route the [NavKey] this Composable function binds to.
- * @param metadataProvider an object that implements [RouteMetadataProvider] to provide Nav3 metadata for this navigation entry.
- *   Defaults to [EmptyMetadataProvider] which produces an empty metadata map.
+ * @param metadataProvider reference to an object that implements [RouteMetadataProvider] to provide Nav3 metadata for this navigation entry.
+ *   Defaults to [EmptyMetadataProvider] which won't be consumed in the generated [NavEntryInstaller].
  */
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.SOURCE)

--- a/build-logic/routebinding/routebinding-runtime/src/main/kotlin/io/github/reactivecircus/routebinding/runtime/RouteMetadataProvider.kt
+++ b/build-logic/routebinding/routebinding-runtime/src/main/kotlin/io/github/reactivecircus/routebinding/runtime/RouteMetadataProvider.kt
@@ -1,7 +1,7 @@
 package io.github.reactivecircus.routebinding.runtime
 
 /**
- * Provides metadata for a route binding entry.
+ * Provides Nav3 metadata for a route binding entry.
  *
  * Implementations supply a `Map<String, Any>` that is passed as the `metadata` argument
  * to Nav3's `entry` function in the generated [NavEntryInstaller].
@@ -11,7 +11,7 @@ public interface RouteMetadataProvider {
 }
 
 /**
- * Default no-op [RouteMetadataProvider] that produces an empty metadata map.
+ * Default no-op [RouteMetadataProvider] that won't be consumed in the generated [NavEntryInstaller].
  */
 internal object EmptyMetadataProvider : RouteMetadataProvider {
     override fun provide(): Map<String, Any> = emptyMap()

--- a/build-logic/routebinding/routebinding-runtime/src/main/kotlin/io/github/reactivecircus/routebinding/runtime/RouteMetadataProvider.kt
+++ b/build-logic/routebinding/routebinding-runtime/src/main/kotlin/io/github/reactivecircus/routebinding/runtime/RouteMetadataProvider.kt
@@ -13,6 +13,6 @@ public interface RouteMetadataProvider {
 /**
  * Default no-op [RouteMetadataProvider] that produces an empty metadata map.
  */
-public object EmptyMetadataProvider : RouteMetadataProvider {
+internal object EmptyMetadataProvider : RouteMetadataProvider {
     override fun provide(): Map<String, Any> = emptyMap()
 }

--- a/build-logic/routebinding/routebinding-runtime/src/main/kotlin/io/github/reactivecircus/routebinding/runtime/RouteMetadataProvider.kt
+++ b/build-logic/routebinding/routebinding-runtime/src/main/kotlin/io/github/reactivecircus/routebinding/runtime/RouteMetadataProvider.kt
@@ -1,0 +1,18 @@
+package io.github.reactivecircus.routebinding.runtime
+
+/**
+ * Provides metadata for a route binding entry.
+ *
+ * Implementations supply a `Map<String, Any>` that is passed as the `metadata` argument
+ * to Nav3's `entry` function in the generated [NavEntryInstaller].
+ */
+public interface RouteMetadataProvider {
+    public fun provide(): Map<String, Any>
+}
+
+/**
+ * Default no-op [RouteMetadataProvider] that produces an empty metadata map.
+ */
+public object EmptyMetadataProvider : RouteMetadataProvider {
+    override fun provide(): Map<String, Any> = emptyMap()
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -143,6 +143,7 @@ sqldelight-nativeDriver = { module = "app.cash.sqldelight:native-driver", versio
 sqldelight-sqliteDriver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
 ksoup = { module = "com.fleeksoft.ksoup:ksoup", version.ref = "ksoup" }
 licentia-runtime = { module = "io.github.reactivecircus.licentia:licentia-runtime" }
+routebinding-runtime = { module = "io.github.reactivecircus.routebinding:routebinding-runtime" }
 kotlin-test-junit = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit", version.ref = "kotlin" }
 paparazzi = { module = "app.cash.paparazzi:paparazzi", version.ref = "paparazzi" }
 burst = { module = "app.cash.burst:burst", version.ref = "burst" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -110,6 +110,7 @@ includeAndroidProjects(
     ":feature:talking-kotlin-episode:impl",
     ":core:designsystem",
     ":core:launcher",
+    ":core:route-metadata",
     ":core:scheduled-work",
     ":core:screenshot-testing:tester",
     ":core:screenshot-testing:paparazzi",


### PR DESCRIPTION
Define an object Implementing `RouteMetadataProvider` using a key that implements `NavMetadataKey`:

```kt
public object BottomSheetMetadataProvider : RouteMetadataProvider {
    override fun provide(): Map<String, Any> = metadata { put(BottomSheetMetadataKey, Unit) }
}

public data object BottomSheetMetadataKey : NavMetadataKey<Unit>
```

Reference the metadata provider object from the `@RouteBinding` annotation:

```kt
@RouteBinding(FeedSelectionRoute::class, metadataProvider = BottomSheetMetadataProvider::class)
@Composable
internal fun FeedSelectionBottomSheet() {...}
```

Use the same metadata key used by the `RouteMetadataProvider` object when implementing the associated Nav3 `SceneStrategy`:

```kt
class BottomSheetSceneStrategy<T : Any> : SceneStrategy<T> {
    override fun SceneStrategyScope<T>.calculateScene(entries: List<NavEntry<T>>): Scene<T>? {
        val lastEntry = entries.lastOrNull() ?: return null
        lastEntry.metadata[BottomSheetMetadataKey] ?: return null
        ...
    }
}
```